### PR TITLE
Fix attempt to call #visit on NilClass

### DIFF
--- a/lib/ahoy/model.rb
+++ b/lib/ahoy/model.rb
@@ -13,7 +13,7 @@ module Ahoy
       end
       class_eval %Q{
         def set_visit
-          self.#{name} ||= RequestStore.store[:ahoy].visit
+          self.#{name} ||= RequestStore.store[:ahoy].try(:visit)
         end
       }
     end


### PR DESCRIPTION
Hi,

The change to remove a try call here actually broke Ahoy when running outside of the context of an app server. Specifically, once I upgraded to 1.0 I ended up getting a bunch of exceptions raised all over the place in my specs due to them trying to call #visit on RequestStore.store[:ahoy], which was always nil. It's not safe to assume in model code that the RequestStore will be present or initialized as that's really only something that exists in the context of a request. This quick change resolved the issue for me and allowed my specs to run as normal.

Thanks for the great work!

Cheers,
James
