### PR TITLE
feature detect correct mongoid BSON implementation

### DIFF
--- a/lib/ahoy/stores/mongoid_store.rb
+++ b/lib/ahoy/stores/mongoid_store.rb
@@ -51,7 +51,14 @@ module Ahoy
       end
 
       def binary(token)
-        ::BSON::Binary.new(token.delete("-"), :uuid)
+        case
+          when defined?(::Moped::BSON)
+            ::BSON::Binary.new(:uuid, token.delete("-"))
+          when defined?(::BSON)
+            ::BSON::Binary.new(token.delete("-"), :uuid)
+          else
+            raise 'no BSON!'
+        end
       end
 
     end

--- a/lib/generators/ahoy/stores/templates/mongoid_visit_model.rb
+++ b/lib/generators/ahoy/stores/templates/mongoid_visit_model.rb
@@ -5,7 +5,16 @@ class Visit
   belongs_to :user
 
   # required
-  field :visitor_id, type: BSON::Binary
+  type =
+    case
+      when defined?(::Moped::BSON)
+        ::Moped::BSON::Binary
+      when defined?(::BSON)
+        ::BSON::Binary
+      else
+        raise 'no BSON!'
+    end
+  field :visitor_id, type: type
 
   # the rest are recommended but optional
   # simply remove the columns you don't want


### PR DESCRIPTION
you can't rely on ::BSON just because mongoid is in use.  this patch recognizes Moped::BSON as per http://mongoid.org/en/moped/docs/bson.html
