### PR TITLE
Allow controller filters specified to be run

### DIFF
--- a/app/controllers/ahoy/base_controller.rb
+++ b/app/controllers/ahoy/base_controller.rb
@@ -1,10 +1,20 @@
 module Ahoy
   class BaseController < ApplicationController
     # skip all filters
-    skip_filter *_process_action_callbacks.map(&:filter)
+    skip_filter :skip_filters
 
     def ahoy
       @ahoy ||= Ahoy::Tracker.new(controller: self, api: true)
+    end
+
+    private
+
+    def filters_to_allow
+      []
+    end
+
+    def skip_filters
+      BaseController._process_action_callbacks.map(&:filter).reject{ |filter| filters_to_allow.include?(filter) }
     end
 
   end


### PR DESCRIPTION
I have a project where I use Authlogic for authentication, and the Authlogic Session information needs to be loaded in a before_filter method for the Base Controller, otherwise it raises an `Authlogic::Session::Activation::NotActivatedError` error.

I've updated the base controller in Ahoy to allow filters specified by the `filters_to_allow` method to be run, so that I can override the `Ahoy::BaseController` in my application and then specify a method to be run and add the method name into my defined `filters_to_allow` method.