### PR TITLE
Fix for referer-parser rewrite

### DIFF
--- a/lib/ahoy/deckhands/traffic_source_deckhand.rb
+++ b/lib/ahoy/deckhands/traffic_source_deckhand.rb
@@ -7,16 +7,16 @@ module Ahoy
       end
 
       def referring_domain
-        @referring_domain ||= Addressable::URI.parse(@referrer).host.first(255) rescue nil
+        @referring_domain ||= (self.class.referrer_parser.parse(@referrer)[:domain][0..255] rescue nil).presence
       end
 
       def search_keyword
-        @search_keyword ||= (self.class.referrer_parser.parse(@referrer)[1].first(255) rescue nil).presence
+        @search_keyword ||= (self.class.referrer_parser.parse(@referrer)[:term][0..255] rescue nil).presence
       end
 
       # performance hack for referer-parser
       def self.referrer_parser
-        @referrer_parser ||= RefererParser::Referer.new("https://github.com/ankane/ahoy")
+        @referrer_parser ||= RefererParser::Parser.new
       end
 
     end


### PR DESCRIPTION
This fix will allow the use of the new RefererParser as it was rewritten here: https://github.com/snowplow/referer-parser/commit/74079f63ae12f89697eb009e990921d4ed091268#diff-cb572531e290df3c55229ed298e17876R19
