### PR TITLE
Make Ahoy.geocode option work for all stores (addresses #50)

### DIFF
--- a/ahoy_matey.gemspec
+++ b/ahoy_matey.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rails"
 end

--- a/lib/ahoy/stores/base_store.rb
+++ b/lib/ahoy/stores/base_store.rb
@@ -67,7 +67,6 @@ module Ahoy
 
       def set_visit_properties(visit)
         keys = visit_properties.keys
-        keys -= Ahoy::VisitProperties::LOCATION_KEYS if Ahoy.geocode != true
         keys.each do |key|
           visit.send(:"#{key}=", visit_properties[key]) if visit.respond_to?(:"#{key}=") && visit_properties[key]
         end

--- a/lib/ahoy/visit_properties.rb
+++ b/lib/ahoy/visit_properties.rb
@@ -25,7 +25,11 @@ module Ahoy
     end
 
     def keys
-      KEYS
+      if Ahoy.geocode
+        KEYS
+      else
+        KEYS - LOCATION_KEYS
+      end
     end
 
     def to_hash

--- a/test/ahoy/visit_properties_test.rb
+++ b/test/ahoy/visit_properties_test.rb
@@ -7,15 +7,28 @@ class TestVisitProperties < Minitest::Test
   end
 
   def test_keys
-    assert_equal @visit_properties.keys, Ahoy::VisitProperties::KEYS
+    with_geocode(true) do
+      assert_equal @visit_properties.keys, Ahoy::VisitProperties::KEYS
+    end
   end
 
   def test_keys_when_geocode_disabled
-    Ahoy.geocode = false
-    keys = @visit_properties.keys
+    with_geocode(false) do
+      keys = @visit_properties.keys
 
-    refute keys.include?(:country)
-    refute keys.include?(:region)
-    refute keys.include?(:city)
+      refute keys.include?(:country)
+      refute keys.include?(:region)
+      refute keys.include?(:city)
+    end
+  end
+
+  private
+
+  def with_geocode(enabled)
+    original = Ahoy.geocode
+    Ahoy.geocode = enabled
+    yield
+  ensure
+    Ahoy.geocode = original
   end
 end

--- a/test/ahoy/visit_properties_test.rb
+++ b/test/ahoy/visit_properties_test.rb
@@ -1,0 +1,21 @@
+require_relative '../test_helper'
+
+class TestVisitProperties < Minitest::Test
+  def setup
+    request = MiniTest::Mock.new
+    @visit_properties = Ahoy::VisitProperties.new(request)
+  end
+
+  def test_keys
+    assert_equal @visit_properties.keys, Ahoy::VisitProperties::KEYS
+  end
+
+  def test_keys_when_geocode_disabled
+    Ahoy.geocode = false
+    keys = @visit_properties.keys
+
+    refute keys.include?(:country)
+    refute keys.include?(:region)
+    refute keys.include?(:city)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,3 @@
+require 'minitest/autorun'
+require 'rails'
+require_relative '../lib/ahoy.rb'


### PR DESCRIPTION
This PR addresses issue #50. 

I noticed that this gem doesn't have any tests - so following the example of your searchkick gem, I've added a test harness using Minitest, and wrote a simple test for the VisitProperties#keys method to assert that it does the right thing. I've introduced that as a separate commit in this PR, in case you want to do something else with your testing. 