### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ And add the javascript file in `app/assets/javascripts/application.js` after jQu
 For Rails 4 and PostgreSQL 9.2 or greater, use:
 
 ```sh
+rails generate migration enable_uuid_ossp_extension
+```
+Then edit the migration.
+
+```ruby
+class EnableUuidOsspExtension < ActiveRecord::Migration
+  def change
+    enable_extension 'uuid-ossp'
+  end
+end
+```
+
+This allows PostgreSQL to generate UUID.
+
+```sh
 rails generate ahoy:stores:active_record -d postgresql
 rake db:migrate
 ```
@@ -267,7 +282,7 @@ Rails actions
 
 ```ruby
 class ApplicationController < ActionController::Base
-  after_filter :track_action
+  after_action :track_action
 
   protected
 


### PR DESCRIPTION
Ahoy setup was working locally, but not passing build on [Codeship](www.codeship.io) because of a `PG::UndefinedFunction:ERROR: function uuid_generate_v4() does not exist`. The fix was to add a migration before generating ahoy files that enabled extension 'uuid-ossp' as mentioned [here](http://rny.io/rails/postgresql/2013/07/27/use-uuids-in-rails-4-with-postgresql.html) and [here](http://blog.arkency.com/2014/10/how-to-start-using-uuid-in-activerecord-with-postgresql/).

``` sh
-- enable_extension("plpgsql")
-> 0.0165s
-- create_table("ahoy_events", {:id=>:uuid, :force=>true})
rake aborted!
ActiveRecord::StatementInvalid: PG::UndefinedFunction: ERROR:  function uuid_generate_v4() does not exist
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
: CREATE TABLE "ahoy_events" ("id" uuid PRIMARY KEY  DEFAULT uuid_generate_v4(), "visit_id" uuid, "user_id" integer, "name" character varying(255), "properties" json, "time" timestamp) 
```

Additionally, after_action is now preferred to after_filter, which meshes well with the Ahoy method name track_action. (Rails commit)[https://github.com/rails/rails/commit/9d62e04838f01f5589fa50b0baa480d60c815e2c]
