### PR TITLE
Attempt to avoid Encoding::UndefinedConversionError.

### DIFF
--- a/lib/ahoy/deckhands/request_deckhand.rb
+++ b/lib/ahoy/deckhands/request_deckhand.rb
@@ -13,7 +13,9 @@ module Ahoy
       end
 
       def user_agent
-        request.user_agent.force_encoding(Encoding::ISO_8859_1).encode(Encoding::UTF_8)
+        if request.user_agent
+          request.user_agent.force_encoding(Encoding::ISO_8859_1).encode(Encoding::UTF_8)
+        end
       end
 
       def referrer

--- a/lib/ahoy/deckhands/request_deckhand.rb
+++ b/lib/ahoy/deckhands/request_deckhand.rb
@@ -13,7 +13,7 @@ module Ahoy
       end
 
       def user_agent
-        request.user_agent
+        request.user_agent.force_encoding(Encoding::ISO_8859_1).encode(Encoding::UTF_8)
       end
 
       def referrer

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -104,7 +104,8 @@ module Ahoy
 
     def set_cookie(name, value, duration = nil)
       cookie = {
-        value: value
+        value: value,
+        secure: true
       }
       cookie[:expires] = duration.from_now if duration
       domain = Ahoy.cookie_domain || Ahoy.domain

--- a/test/visit_properties_test.rb
+++ b/test/visit_properties_test.rb
@@ -35,8 +35,13 @@ class TestVisitProperties < Minitest::Test
   def test_user_agent_header_encoding
     raw_user_agent = "FBCR/M\xE9ditel"
     encoded_user_agent = "FBCR/Méditel"
-    @request.expect(:user_agent, raw_user_agent)
+    2.times { @request.expect(:user_agent, raw_user_agent) }
     assert_equal @visit_properties.user_agent, encoded_user_agent
+  end
+
+  def test_nil_user_agent
+    @request.expect(:user_agent, nil)
+    assert_equal @visit_properties.user_agent, nil
   end
 
   private

--- a/test/visit_properties_test.rb
+++ b/test/visit_properties_test.rb
@@ -2,8 +2,8 @@ require_relative "test_helper"
 
 class TestVisitProperties < Minitest::Test
   def setup
-    request = MiniTest::Mock.new
-    @visit_properties = Ahoy::VisitProperties.new(request)
+    @request = MiniTest::Mock.new
+    @visit_properties = Ahoy::VisitProperties.new(@request)
   end
 
   def test_keys
@@ -30,6 +30,13 @@ class TestVisitProperties < Minitest::Test
       refute keys.include?(:region)
       refute keys.include?(:city)
     end
+  end
+
+  def test_user_agent_header_encoding
+    raw_user_agent = "FBCR/M\xE9ditel"
+    encoded_user_agent = "FBCR/Méditel"
+    @request.expect(:user_agent, raw_user_agent)
+    assert_equal @visit_properties.user_agent, encoded_user_agent
   end
 
   private


### PR DESCRIPTION
We've been seeing this error in our Rails app in production when a request is
made to the `Ahoy::VisitsController#create` action when the user-agent HTTP
header contains non-ASCII characters.

According to RFC5987 [1](http://tools.ietf.org/html/rfc5987):

> By default, message header field parameters in Hypertext Transfer Protocol
> (HTTP) messages cannot carry characters outside the ISO-8859-1 character set.

This implies that non-ASCII characters such as 0xE9 (é) should be allowed, but
they result in the exception mentioned above.

I can reproduce the problem locally using a `curl` command like this:

```
curl --user-agent "Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B436 [FBAN/FBIOS;FBAV/18.1.0.14.11;FBBV/5295262;FBDV/iPhone7,2;FBMD/iPhone;FBSN/iPhone OS;FBSV/8.1.1;FBSS/2; FBCR/Méditel;FBID/phone;FBLC/fr_FR;FBOP/5]" --request POST --data "foo=bar" http://localhost:3000/ahoy/visits
```

It feels as if this is something that should be fixed for all HTTP headers and
it should probably be fixed in Rack, or wherever the headers first make it into
Ruby-land.

However, pragmatically, we're only seeing this exception happen for user agents
at the moment, so I've decided to attempt to fix the problem here.

We've been using this fix in production for over a month on a high volume web app without any problems.
