### PR TITLE
Default UUID migration columns to nil

### DIFF
--- a/lib/generators/ahoy/stores/templates/active_record_events_migration.rb
+++ b/lib/generators/ahoy/stores/templates/active_record_events_migration.rb
@@ -1,8 +1,8 @@
 class <%= migration_class_name %> < ActiveRecord::Migration
   def change
     create_table :ahoy_events, id: false do |t|
-      t.uuid :id, primary_key: true
-      t.uuid :visit_id
+      t.uuid :id, default: nil, primary_key: true
+      t.uuid :visit_id, default: nil
 
       # user
       t.integer :user_id

--- a/lib/generators/ahoy/stores/templates/active_record_visits_migration.rb
+++ b/lib/generators/ahoy/stores/templates/active_record_visits_migration.rb
@@ -1,8 +1,8 @@
 class <%= migration_class_name %> < ActiveRecord::Migration
   def change
     create_table :visits, id: false do |t|
-      t.uuid :id, primary_key: true
-      t.uuid :visitor_id
+      t.uuid :id, default: nil, primary_key: true
+      t.uuid :visitor_id, default: nil
 
       # the rest are recommended but optional
       # simply remove the columns you don't want


### PR DESCRIPTION
This removes the need to have the `uuid_generate_v4()` function in Postgres databases.

Related to #59 