### PR TITLE
add location.search to event properties

### DIFF
--- a/vendor/assets/javascripts/ahoy.js
+++ b/vendor/assets/javascripts/ahoy.js
@@ -130,6 +130,7 @@
       id: $target.attr("id"),
       "class": $target.attr("class"),
       page: page,
+      search: location.search,
       section: $target.closest("*[data-section]").data("section")
     };
   }


### PR DESCRIPTION
Seems like a simple enhancement. Useful for us because we use ahoy.js in wordpress deployments where pages are indicated by query parameters: /?p=591
