### PR TITLE
Support for postal code and lat/lng in visit record

### DIFF
--- a/lib/ahoy/deckhands/location_deckhand.rb
+++ b/lib/ahoy/deckhands/location_deckhand.rb
@@ -14,6 +14,10 @@ module Ahoy
         location.try(:state).presence
       end
 
+      def postal_code
+        location.try(:postal_code).presence
+      end
+
       def city
         location.try(:city).presence
       end

--- a/lib/ahoy/visit_properties.rb
+++ b/lib/ahoy/visit_properties.rb
@@ -5,7 +5,7 @@ module Ahoy
     TRAFFIC_SOURCE_KEYS = [:referring_domain, :search_keyword]
     UTM_PARAMETER_KEYS = [:utm_source, :utm_medium, :utm_term, :utm_content, :utm_campaign]
     TECHNOLOGY_KEYS = [:browser, :os, :device_type]
-    LOCATION_KEYS = [:country, :region, :city, :latitude, :longitude]
+    LOCATION_KEYS = [:country, :postal_code, :region, :city, :latitude, :longitude]
 
     KEYS = REQUEST_KEYS + TRAFFIC_SOURCE_KEYS + UTM_PARAMETER_KEYS + TECHNOLOGY_KEYS + LOCATION_KEYS
 

--- a/lib/generators/ahoy/stores/templates/active_record_visits_migration.rb
+++ b/lib/generators/ahoy/stores/templates/active_record_visits_migration.rb
@@ -32,6 +32,9 @@ class <%= migration_class_name %> < ActiveRecord::Migration
       t.string :country
       t.string :region
       t.string :city
+      t.string :postal_code
+      t.float  :latitude
+      t.float  :longitude
 
       # utm parameters
       t.string :utm_source


### PR DESCRIPTION
Allowing postal code to be stored alongside latitude and longitude in the visit record.  This makes it easier to do proximity searches with geocoder on the visit model.  Postal code is available in the location so it should be an option to store it if the users desire so.