### PR TITLE
changed 'visitor_id' to 'visitor_token' to solve foreign key constraints

### DIFF
--- a/lib/generators/ahoy/stores/templates/active_record_visits_migration.rb
+++ b/lib/generators/ahoy/stores/templates/active_record_visits_migration.rb
@@ -2,7 +2,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
   def change
     create_table :visits, id: false do |t|
       t.uuid :id, default: nil, primary_key: true
-      t.uuid :visitor_id, default: nil
+      t.uuid :visitor_token, default: nil
 
       # the rest are recommended but optional
       # simply remove the columns you don't want


### PR DESCRIPTION
Default config threw this error for me:

```bash
PG::UndefinedTable: ERROR:  relation "visitors" does not exist
: CREATE TABLE "visits" ("id" uuid PRIMARY KEY , "visitor_id" uuid, "ip" character varying(255), "user_agent" text, "referrer" text, "landing_page" text, "user_id" integer, "referring_domain" character varying(255), "search_keyword" character varying(255), "browser" character varying(255), "os" character varying(255), "device_type" character varying(255), "screen_height" integer, "screen_width" integer, "country" character varying(255), "region" character varying(255), "city" character varying(255), "latitude" character varying(255), "longitude" character varying(255), "utm_source" character varying(255), "utm_medium" character varying(255), "utm_term" character varying(255), "utm_content" character varying(255), "utm_campaign" character varying(255), "started_at" timestamp, CONSTRAINT fk_visits_visitor_id FOREIGN KEY ("visitor_id") REFERENCES "visitors" ("id"), CONSTRAINT fk_visits_user_id FOREIGN KEY ("user_id") REFERENCES "users" ("id"))
```
 
Suggesting we move to using visitor_token for visitor identifier