### PR TITLE
fix AssociationTypeMismatch for user

### DIFF
--- a/lib/ahoy/stores/active_record_store.rb
+++ b/lib/ahoy/stores/active_record_store.rb
@@ -6,7 +6,7 @@ module Ahoy
           visit_model.new do |v|
             v.id = ahoy.visit_id
             v.visitor_id = ahoy.visitor_id
-            v.user = user if v.respond_to?(:user=)
+            v.user = user.reload if v.respond_to?(:user=)
             v.started_at = options[:started_at]
           end
 
@@ -27,7 +27,7 @@ module Ahoy
           event_model.new do |e|
             e.id = options[:id]
             e.visit_id = ahoy.visit_id
-            e.user = user
+            e.user = user.reload
             e.name = name
             e.properties = properties
             e.time = options[:time]


### PR DESCRIPTION
Fixes #90

It seems this error occurs when two different versions of the model have been loaded.