### PR TITLE
Return tracked event instead of true

### DIFF
--- a/lib/ahoy/stores/active_record_store.rb
+++ b/lib/ahoy/stores/active_record_store.rb
@@ -37,6 +37,7 @@ module Ahoy
 
         begin
           event.save!
+          event
         rescue *unique_exception_classes
           # do nothing
         end

--- a/lib/ahoy/stores/active_record_token_store.rb
+++ b/lib/ahoy/stores/active_record_token_store.rb
@@ -51,6 +51,7 @@ module Ahoy
           yield(event) if block_given?
 
           event.save!
+          event
         end
       end
 

--- a/lib/ahoy/stores/log_store.rb
+++ b/lib/ahoy/stores/log_store.rb
@@ -28,6 +28,8 @@ module Ahoy
         yield(data) if block_given?
 
         event_logger.info data.to_json
+
+        data
       end
 
       protected

--- a/lib/ahoy/stores/mongoid_store.rb
+++ b/lib/ahoy/stores/mongoid_store.rb
@@ -32,6 +32,7 @@ module Ahoy
         yield(event) if block_given?
 
         event.upsert
+        event
       end
 
       def visit

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -16,9 +16,9 @@ module Ahoy
         options[:time] = trusted_time(options[:time])
         options[:id] = ensure_uuid(options[:id] || generate_id)
 
-        @store.track_event(name, properties, options)
+        event = @store.track_event(name, properties, options)
+        event
       end
-      true
     rescue => e
       report_exception(e)
     end


### PR DESCRIPTION
Useful when you need to perform a custom background job (or anything else) on the event, once it has been tracked with `ahoy.track`.

You could arguably get the event from `ahoy.visit.ahoy_events.last` after a `ahoy.track`. But getting the event directly as the return value of `ahoy.track` is handier. It is also more correct, because we are sure to get the event the current thread/process just `ahoy.track`'ed.