### PR TITLE
Fix issue where /ahoy/visits is called indefinitely when Ahoy.cookie_domain = :all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 1.2.0 [unreleased]
+## 1.2.0.rc1
 
 - Added Fluentd store
 - Added latitude, longitude, and postal_code to visits
+- Fix issue where /ahoy/visits is called indefinitely when Ahoy.cookie_domain = :all
 
 ## 1.1.1
 

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -26,7 +26,7 @@ module Ahoy
     def track_visit(options = {})
       unless exclude?
         if options[:defer]
-          set_cookie("ahoy_track", true)
+          set_track_cookie
         else
           options = options.dup
 
@@ -65,13 +65,17 @@ module Ahoy
       !existing_visit_id
     end
 
+    def set_track_cookie
+      set_cookie("ahoy_track", true, domain: :none)
+    end
+
     def set_visit_cookie
-      set_cookie("ahoy_visit", visit_id, Ahoy.visit_duration)
+      set_cookie("ahoy_visit", visit_id, duration: Ahoy.visit_duration)
     end
 
     def set_visitor_cookie
       unless existing_visitor_id
-        set_cookie("ahoy_visitor", visitor_id, Ahoy.visitor_duration)
+        set_cookie("ahoy_visitor", visitor_id, duration: Ahoy.visitor_duration)
       end
     end
 
@@ -96,13 +100,13 @@ module Ahoy
 
     protected
 
-    def set_cookie(name, value, duration = nil)
+    def set_cookie(name, value, duration: nil, domain: nil)
       cookie = {
         value: value
       }
       cookie[:expires] = duration.from_now if duration
-      domain = Ahoy.cookie_domain || Ahoy.domain
-      cookie[:domain] = domain if domain
+      domain ||= Ahoy.cookie_domain || Ahoy.domain
+      cookie[:domain] = domain if domain && domain != :none
       request.cookie_jar[name] = cookie
     end
 

--- a/lib/ahoy/version.rb
+++ b/lib/ahoy/version.rb
@@ -1,3 +1,3 @@
 module Ahoy
-  VERSION = "1.1.1"
+  VERSION = "1.2.0.rc1"
 end


### PR DESCRIPTION
`ahoy.js` isn't able to destroy cookie's with `domain: :all` (unless `ahoy.domain` is set using javascript, which is not documented and a hacky solution). This results in `ahoy_track` cookie passed between client and server indefinitely when `Ahoy.cookie_domain` is set to `:all`. This creates an issue where `/ahoy/vists` called indefinitely with every request.

Also releases `1.2.0.rc1` so that it can be safely published/used via rubygems