### PR TITLE
'page' property is not updated when used with Turbolinks

### DIFF
--- a/vendor/assets/javascripts/ahoy.js
+++ b/vendor/assets/javascripts/ahoy.js
@@ -20,7 +20,6 @@
   var queue = [];
   var canStringify = typeof(JSON) !== "undefined" && typeof(JSON.stringify) !== "undefined";
   var eventQueue = [];
-  var page = ahoy.page || window.location.pathname;
   var visitsUrl = ahoy.visitsUrl || "/ahoy/visits"
   var eventsUrl = ahoy.eventsUrl || "/ahoy/events"
 
@@ -123,13 +122,17 @@
     });
   }
 
+  function page() {
+    return ahoy.page || window.location.pathname;
+  }
+
   function eventProperties(e) {
     var $target = $(e.currentTarget);
     return {
       tag: $target.get(0).tagName.toLowerCase(),
       id: $target.attr("id"),
       "class": $target.attr("class"),
-      page: page,
+      page: page(),
       section: $target.closest("*[data-section]").data("section")
     };
   }
@@ -234,7 +237,7 @@
     var properties = {
       url: window.location.href,
       title: document.title,
-      page: page
+      page: page()
     };
     ahoy.track("$view", properties);
   };


### PR DESCRIPTION
I've recently added Ahoy to a site that also uses Turbolinks. I've hooked it in so that `ahoy.trackView()` is called when Turbolinks' `page:load` event is fired. One issue I noticed is that the 'page' property of each '$view' event is the same when called this way.

This is because the value of the `page` variable is set once when the `ahoy.js` script is evaluated, [here](https://github.com/ankane/ahoy/blob/master/vendor/assets/javascripts/ahoy.js#L23). Updating `window.ahoy.page` has no effect because the value of the closure is inaccessible.

I'm experimenting with a version of the code where `page` is a function, but I'm not sure if this is the best solution yet.
