### PR TITLE
Add option to change the ActiveJob queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,12 @@ Or disable it with:
 Ahoy.geocode = false
 ```
 
+To change the queue name (`ahoy` by default):
+
+```ruby
+Ahoy.job_queue = :low_priority
+```
+
 ### Track Visits Immediately
 
 Visitor and visit ids are generated on the first request (so you can use them immediately), but the `track_visit` method isn’t called until the JavaScript library posts to the server.  This prevents browsers with cookies disabled from creating multiple visits and ensures visits are not created for API endpoints.  Change this with:

--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -59,6 +59,9 @@ module Ahoy
   mattr_accessor :geocode
   self.geocode = true
 
+  mattr_accessor :job_queue
+  self.job_queue = :ahoy
+
   def self.ensure_uuid(id)
     valid = UUIDTools::UUID.parse(id) rescue nil
     if valid

--- a/lib/ahoy/stores/base_store.rb
+++ b/lib/ahoy/stores/base_store.rb
@@ -73,7 +73,7 @@ module Ahoy
 
       def geocode(visit)
         if Ahoy.geocode == :async
-          Ahoy::GeocodeJob.perform_later(visit)
+          Ahoy::GeocodeJob.set(queue: Ahoy.job_queue).perform_later(visit)
         end
       end
 


### PR DESCRIPTION
This adds this setting to run the geocoding process in a custom queue (instead of `ahoy`):

```ruby
Ahoy.job_queue = :low_priority
```