### PR TITLE
add configuration and docs to use alternatives to RequestStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,18 @@ You can exclude API endpoints and other actions with:
 skip_before_action :track_ahoy_visit
 ```
 
+### Alternative Request Storage
+
+By default Ahoy uses [RequestStore](https://github.com/steveklabnik/request_store) but you can create your own or use another by configuring the storage in your initializer.
+
+```ruby
+Ahoy.request_store = MyCustomHash.instance
+```
+
+Make sure that your custom request store responds to `store` which returns an object responding to `:[]`.
+
+For example [RequestStoreRails](https://github.com/ElMassimo/request_store_rails).
+
 ## Development
 
 Ahoy is built with developers in mind.  You can run the following code in your browser’s console.

--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -105,6 +105,9 @@ module Ahoy
 
   mattr_accessor :track_bots
   self.track_bots = false
+
+  mattr_accessor :request_store
+  self.request_store = RequestStore
 end
 
 if defined?(Rails)

--- a/lib/ahoy/controller.rb
+++ b/lib/ahoy/controller.rb
@@ -1,5 +1,3 @@
-require "request_store"
-
 module Ahoy
   module Controller
     def self.included(base)
@@ -36,7 +34,7 @@ module Ahoy
     end
 
     def set_ahoy_request_store
-      RequestStore.store[:ahoy] ||= ahoy
+      Ahoy.request_store.store[:ahoy] ||= ahoy
     end
   end
 end

--- a/lib/ahoy/model.rb
+++ b/lib/ahoy/model.rb
@@ -12,7 +12,7 @@ module Ahoy
       end
       class_eval %{
         def set_visit
-          self.#{name} ||= RequestStore.store[:ahoy].try(:visit)
+          self.#{name} ||= Ahoy.request_store.store[:ahoy].try(:visit)
         end
       }
     end


### PR DESCRIPTION
I'm using an alternative to RequestStore from https://github.com/ElMassimo/request_store_rails

These changes allow you to set the module's `request_store` to something different.

``` ruby
Ahoy.request_store = RequestLocals
```

Without these changes I'd need to do something like `Object.const_set(:RequestStore, RequestLocals)` to get it to work with the alternative. It made sense to have it be configurable however.

I want to add tests but I don't know what pattern to follow. Is there currently any plan to add more tests to this gem? Can you point me in the right direction? Or is that something I can help do in other PRs?
