### PR TITLE
allow alternative background implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,24 @@ Or disable geocoding with:
 Ahoy.geocode = false
 ```
 
+#### Custom Geocoders and Background Jobs
+
+Ahoy provides inline geocoding through the Ahoy::Geocoder but you can implement your own class by setting the `geocoder` option:
+
+```ruby
+Ahoy.geocoder = CustomGeocoder
+```
+
+Your class will be initialized by Ahoy and the `geocode` method will be called and provided an instance of your configured `visit_model`.
+
+If you want to provide your own background job you can set it the same way:
+
+```ruby
+Ahoy.geocoder = CustomBackgroundGeocoder
+```
+
+Note that this would be equivalent to setting `Ahoy.geocode = :async` but allows you to provide additional features or processing in your own background processing class.
+
 ### Track Visits Immediately
 
 Visitor and visit ids are generated on the first request (so you can use them immediately), but the `track_visit` method isn’t called until the JavaScript library posts to the server.  This prevents browsers with cookies disabled from creating multiple visits and ensures visits are not created for API endpoints.  Change this with:

--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -38,6 +38,7 @@ begin
 rescue LoadError
   # do nothing
 end
+require "ahoy/geocoder"
 require "ahoy/geocode_job" if defined?(ActiveJob)
 
 # deprecated
@@ -60,7 +61,17 @@ module Ahoy
   mattr_accessor :quiet
   self.quiet = true
 
+  mattr_accessor :geocoder
   mattr_accessor :geocode
+
+  def self.geocode=(val)
+    @@geocode = val
+    if val == :async
+      self.geocoder ||= GeocodeJob
+    elsif val == true
+      self.geocoder ||= Geocoder.new
+    end
+  end
   self.geocode = true
 
   mattr_accessor :max_content_length

--- a/lib/ahoy/geocode_job.rb
+++ b/lib/ahoy/geocode_job.rb
@@ -3,11 +3,11 @@ module Ahoy
     queue_as :ahoy
 
     def perform(visit)
-      deckhand = Deckhands::LocationDeckhand.new(visit.ip)
-      Ahoy::VisitProperties::LOCATION_KEYS.each do |key|
-        visit.send(:"#{key}=", deckhand.send(key)) if visit.respond_to?(:"#{key}=")
-      end
-      visit.save!
+      Geocoder.new.geocode(visit)
+    end
+
+    def geocode(visit)
+      perform_later(visit)
     end
   end
 end

--- a/lib/ahoy/geocoder.rb
+++ b/lib/ahoy/geocoder.rb
@@ -1,0 +1,11 @@
+module Ahoy
+  class Geocoder
+    def geocode(visit)
+      deckhand = Deckhands::LocationDeckhand.new(visit.ip)
+      Ahoy::VisitProperties::LOCATION_KEYS.each do |key|
+        visit.send(:"#{key}=", deckhand.send(key)) if visit.respond_to?(:"#{key}=")
+      end
+      visit.save!
+    end
+  end
+end

--- a/lib/ahoy/stores/base_store.rb
+++ b/lib/ahoy/stores/base_store.rb
@@ -72,8 +72,8 @@ module Ahoy
       end
 
       def geocode(visit)
-        if Ahoy.geocode == :async
-          Ahoy::GeocodeJob.set(queue: Ahoy.job_queue).perform_later(visit)
+        unless Ahoy.geocode == false
+          Ahoy.geocoder.geocode(visit)
         end
       end
 


### PR DESCRIPTION
In my project I use a non-ActiveJob background job processer (https://github.com/chanks/que)

I'd love some feedback on these changes.

The changes allow me to create my own background job class, and use the existing code from this gem for the geocoding behavior.

For example, I might want to have my project setup like this:

``` ruby
class LaterGeo < Que::Job
  def run(visit)
    ::Ahoy::Geocoder.new.geocode(visit)
  end

  def geocode(visit)
    run(visit)
  end
end
Ahoy.geocoder = LaterGeo.new
```

These changes might also need further adjustment.
For example, we can set `Ahoy.geocode = :async` or true/false, but it would probably make sense just to assign `Ahoy.geocoder = ...`
Using true/false/:async is much easier for users of the library, but setting a geocoding object is much more flexible.
One idea I had was to make a null object to simplify any value checking. For example the implementation of `BaseStore` in my changes looks like this

``` ruby
      def geocode(visit)
        unless Ahoy.geocode == false
          Ahoy.geocoder.geocode(visit)
        end
      end
```

But with a null object, it could be just

``` ruby
class NoGeo
  def geocode(visit); end
end
Ahoy.geocoder = NoGeo.new

# in BaseStore...
      def geocode(visit)
        Ahoy.geocoder.geocode(visit)
      end
```

Setting the `geocoder` option that I've added requires some knowledge of these objects, so perhaps there's a proper balance between setting true/false/:async but allowing alternatives.
