### PR TITLE
move os_version to technology_deckhand

### DIFF
--- a/lib/ahoy/deckhands/request_deckhand.rb
+++ b/lib/ahoy/deckhands/request_deckhand.rb
@@ -32,10 +32,6 @@ module Ahoy
         request.params["app_version"]
       end
 
-      def os_version
-        request.params["os_version"]
-      end
-
       def screen_height
         request.params["screen_height"]
       end

--- a/lib/ahoy/deckhands/technology_deckhand.rb
+++ b/lib/ahoy/deckhands/technology_deckhand.rb
@@ -13,6 +13,10 @@ module Ahoy
         agent.os.name
       end
 
+      def os_version
+        agent.os.version
+      end
+
       def device_type
         @device_type ||= begin
           browser = Browser.new(ua: @user_agent)

--- a/lib/ahoy/visit_properties.rb
+++ b/lib/ahoy/visit_properties.rb
@@ -1,9 +1,9 @@
 module Ahoy
   class VisitProperties
-    REQUEST_KEYS = [:ip, :user_agent, :referrer, :landing_page, :platform, :app_version, :os_version, :screen_height, :screen_width]
+    REQUEST_KEYS = [:ip, :user_agent, :referrer, :landing_page, :platform, :app_version, :screen_height, :screen_width]
     TRAFFIC_SOURCE_KEYS = [:referring_domain, :search_keyword]
     UTM_PARAMETER_KEYS = [:utm_source, :utm_medium, :utm_term, :utm_content, :utm_campaign]
-    TECHNOLOGY_KEYS = [:browser, :os, :device_type]
+    TECHNOLOGY_KEYS = [:browser, :os, :os_version, :device_type]
     LOCATION_KEYS = [:country, :region, :city, :postal_code, :latitude, :longitude]
 
     KEYS = REQUEST_KEYS + TRAFFIC_SOURCE_KEYS + UTM_PARAMETER_KEYS + TECHNOLOGY_KEYS + LOCATION_KEYS


### PR DESCRIPTION
I think `os_version` should stick with `os` and it can be got by agent. Am I right?
