### PR TITLE
replace *_filter with *_action

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Rails actions
 
 ```ruby
 class ApplicationController < ActionController::Base
-  after_filter :track_action
+  after_action :track_action
 
   protected
 
@@ -393,7 +393,7 @@ Ahoy.track_visits_immediately = true
 You can exclude API endpoints and other actions with:
 
 ```ruby
-skip_before_filter :track_ahoy_visit
+skip_before_action :track_ahoy_visit
 ```
 
 ## Development

--- a/app/controllers/ahoy/base_controller.rb
+++ b/app/controllers/ahoy/base_controller.rb
@@ -1,7 +1,7 @@
 module Ahoy
   class BaseController < ApplicationController
-    # skip all filters except for authlogic
-    skip_filter *(_process_action_callbacks.map(&:filter) - [:load_authlogic])
+    # skip all actions except for authlogic
+    skip_action(*(_process_action_callbacks.map(&:filter) - [:load_authlogic]))
 
     def ahoy
       @ahoy ||= Ahoy::Tracker.new(controller: self, api: true)

--- a/lib/ahoy/controller.rb
+++ b/lib/ahoy/controller.rb
@@ -5,9 +5,9 @@ module Ahoy
     def self.included(base)
       base.helper_method :current_visit
       base.helper_method :ahoy
-      base.before_filter :set_ahoy_cookies
-      base.before_filter :track_ahoy_visit
-      base.before_filter do
+      base.before_action :set_ahoy_cookies
+      base.before_action :track_ahoy_visit
+      base.before_action do
         RequestStore.store[:ahoy] ||= ahoy
       end
     end


### PR DESCRIPTION
This PR will help with getting Ahoy Rails 5 ready :)

```
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead.
```