### PR TITLE
Update logger_silencer for Rails 5 Compatibility

### DIFF
--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -94,10 +94,10 @@ begin
   require "active_record/session_store/extension/logger_silencer"
 rescue LoadError
   require "ahoy/logger_silencer"
-  Logger.send(:prepend, Ahoy::LoggerSilencer)
+  Logger.send :include, Ahoy::LoggerSilencer
 
   begin
     require "syslog/logger"
-    Syslog::Logger.send(:prepend, Ahoy::LoggerSilencer)
+    Syslog::Logger.send :include, Ahoy::LoggerSilencer
   rescue LoadError; end
 end

--- a/lib/ahoy/logger_silencer.rb
+++ b/lib/ahoy/logger_silencer.rb
@@ -54,9 +54,9 @@ module Ahoy
 
     for severity in Logger::Severity.constants
       class_eval <<-EOT, __FILE__, __LINE__ + 1
-        def #{severity.downcase}?                # def debug?
-          Logger::#{severity} >= level           #   DEBUG >= level
-        end                                      # end
+        def #{severity.downcase}?                         # def debug?
+          Logger::#{severity} >= level_with_threadsafety  #   DEBUG >= level
+        end                                               # end
       EOT
     end
 

--- a/lib/ahoy/logger_silencer.rb
+++ b/lib/ahoy/logger_silencer.rb
@@ -54,9 +54,9 @@ module Ahoy
 
     for severity in Logger::Severity.constants
       class_eval <<-EOT, __FILE__, __LINE__ + 1
-        def #{severity.downcase}?                         # def debug?
-          Logger::#{severity} >= level_with_threadsafety  #   DEBUG >= level
-        end                                               # end
+        def #{severity.downcase}?                # def debug?
+          Logger::#{severity} >= level           #   DEBUG >= level
+        end                                      # end
       EOT
     end
 


### PR DESCRIPTION
Copied from https://github.com/rails/activerecord-session_store/blob/master/lib/active_record/session_store/extension/logger_silencer.rb to pull in rails 5 compatibility updates