### PR TITLE
fix passing argument to Browser.new

### DIFF
--- a/ahoy_matey.gemspec
+++ b/ahoy_matey.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails"
   spec.add_dependency "addressable"
-  spec.add_dependency "browser", ">= 0.4.0"
+  spec.add_dependency "browser", "~> 2.0"
   spec.add_dependency "geocoder"
   spec.add_dependency "referer-parser", ">= 0.3.0"
   spec.add_dependency "user_agent_parser"

--- a/lib/ahoy/deckhands/technology_deckhand.rb
+++ b/lib/ahoy/deckhands/technology_deckhand.rb
@@ -15,16 +15,16 @@ module Ahoy
 
       def device_type
         @device_type ||= begin
-          browser = Browser.new(ua: @user_agent)
+          browser = Browser.new(@user_agent)
           if browser.bot?
             "Bot"
-          elsif browser.tv?
+          elsif browser.device.tv?
             "TV"
-          elsif browser.console?
+          elsif browser.device.console?
             "Console"
-          elsif browser.tablet?
+          elsif browser.device.tablet?
             "Tablet"
-          elsif browser.mobile?
+          elsif browser.device.mobile?
             "Mobile"
           else
             "Desktop"

--- a/lib/ahoy/stores/base_store.rb
+++ b/lib/ahoy/stores/base_store.rb
@@ -45,7 +45,7 @@ module Ahoy
       protected
 
       def bot?
-        @bot ||= request ? Browser.new(ua: request.user_agent).bot? : false
+        @bot ||= request ? Browser.new(request.user_agent).bot? : false
       end
 
       def request


### PR DESCRIPTION
1)I noted gem Browser is using string as user agent variable:
```ruby
module Browser
  class Base
    attr_reader :ua
    def initialize(ua, accept_language: nil)
      @ua = ua
    end
   ...
   def bot
      @bot ||= Bot.new(ua)
    end
end

module Browser
  class Bot
    attr_reader :ua
    def initialize(ua)
      @ua = ua
    end
   ...
   def downcased_ua
      @downcased_ua ||= ua.downcase
   end
  end
end
```
But ahoy creates Browser instance with hash as user agent:
`Browser.new(ua: request.user_agent)`
And we get an error in downcased_ua `NoMethodError: undefined method downcase' for Hash`

2) Inheritors of Browser::Base (sach as Browser::Chrome) have no methods `.tv?`, `.console?`, `.tablet?` and `.mobile?`. These methods is instance's methods of Browser::Device

PS: sorry for my English and sorry if I am wrong anywhere