### PR TITLE
Stop monkey patching `Object` when including `safely_block`

### DIFF
--- a/ahoy_matey.gemspec
+++ b/ahoy_matey.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "user_agent_parser"
   spec.add_dependency "request_store"
   spec.add_dependency "uuidtools"
-  spec.add_dependency "safely_block"
+  spec.add_dependency "safely_block", ">= 0.1.1"
   spec.add_dependency "rack-attack"
 
   spec.add_development_dependency "bundler", "~> 1.5"

--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -6,7 +6,7 @@ require "referer-parser"
 require "user_agent_parser"
 require "request_store"
 require "uuidtools"
-require "safely_block"
+require "safely/core"
 
 require "ahoy/version"
 require "ahoy/tracker"

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -126,9 +126,8 @@ module Ahoy
 
     # odd pattern for backwards compatibility
     # TODO remove this method in next major release
-    include Safely::Methods
     def report_exception(e)
-      safely do
+      Safely.safely do
         @store.report_exception(e)
         if Rails.env.development? || Rails.env.test?
           raise e

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -126,6 +126,7 @@ module Ahoy
 
     # odd pattern for backwards compatibility
     # TODO remove this method in next major release
+    include Safely::Methods
     def report_exception(e)
       safely do
         @store.report_exception(e)


### PR DESCRIPTION
Part of #175 