### PR TITLE
Fix deprecation for rack-attrack 5.0.0

### DIFF
--- a/lib/ahoy/throttle.rb
+++ b/lib/ahoy/throttle.rb
@@ -8,7 +8,7 @@ module Ahoy
       end
     end
 
-    def_delegators self, :whitelisted?, :blacklisted?, :throttled?, :tracked?
+    def_delegators self, :safelisted?, :blocklisted?, :whitelisted?, :blacklisted?, :throttled?, :tracked?
 
     def self.throttled_response
       Rack::Attack.throttled_response


### PR DESCRIPTION
Hi Ankane
When I update my gems, I found the `whitelisted?` and `blacklisted?` methods are deprecated since rack-attrack-5.0.0, and I modify this methods' name.

We use ahoy in production to track user's action at our online shopping site, so if there are any feedback please let me know, it would be a great honor for me to help.

thank you
Howard