### PR TITLE
Verify CSRF token when POSTing events and visits

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ And add the javascript file in `app/assets/javascripts/application.js` after jQu
 //= require ahoy
 ```
 
+In your application layout file, make sure the call to `csrf_meta_tags` is
+placed **before** the link to `application.js`. For example, if you're using
+ERB, your `application.html.erb` would include something like this:
+```erb
+<%= csrf_meta_tags %>
+<%= javascript_include_tag 'application' %>
+```
+
 ## Choose a Data Store
 
 Ahoy supports a number of data stores out of the box.  You can start with one of them and customize as needed, or create your own store from scratch.

--- a/app/controllers/ahoy/base_controller.rb
+++ b/app/controllers/ahoy/base_controller.rb
@@ -1,7 +1,9 @@
 module Ahoy
   class BaseController < ApplicationController
-    # skip all filters except for authlogic
-    filters = _process_action_callbacks.map(&:filter) - [:load_authlogic]
+    # skip all filters except for authlogic and verify_authenticity_token
+    filters = _process_action_callbacks.map(&:filter) - [
+      :load_authlogic, :verify_authenticity_token
+    ]
     if Rails::VERSION::MAJOR >= 5
       skip_before_action(*filters, raise: false)
       skip_after_action(*filters, raise: false)

--- a/vendor/assets/javascripts/ahoy.js
+++ b/vendor/assets/javascripts/ahoy.js
@@ -24,6 +24,9 @@
   var eventsUrl = ahoy.eventsUrl || "/ahoy/events";
   var canTrackNow = ahoy.trackNow && canStringify && typeof(window.navigator.sendBeacon) !== "undefined";
 
+  var csrfToken = "";
+  csrfToken = $('meta[name="csrf-token"]').attr('content');
+
   // cookies
 
   // http://www.quirksmode.org/js/cookies.html
@@ -108,6 +111,9 @@
           data: JSON.stringify([event]),
           contentType: "application/json; charset=utf-8",
           dataType: "json",
+          beforeSend: function (xhr) {
+            xhr.setRequestHeader('X-CSRF-Token', csrfToken);
+          },
           success: function() {
             // remove from queue
             for (var i = 0; i < eventQueue.length; i++) {
@@ -191,7 +197,17 @@
 
         log(data);
 
-        $.post(visitsUrl, data, setReady, "json");
+        $.ajax({
+          type: "POST",
+          url: visitsUrl,
+          data: JSON.stringify([data]),
+          contentType: "application/json; charset=utf-8",
+          dataType: "json",
+          beforeSend: function (xhr) {
+            xhr.setRequestHeader('X-CSRF-Token', csrfToken);
+          },
+          success: setReady
+        });
       } else {
         log("Cookies disabled");
         setReady();


### PR DESCRIPTION
**Why**: To prevent unauthorized POST requests to the `/events` and `/visits` endpoints. Without this protection, anyone can write bogus events and visits to any website that uses Ahoy, which is a serious security issue.

**How**:
- Enable the `verify_authenticity_token` `before_action` in the `BaseController`.
- Pass in the CSRF token in the Ajax requests. The accepted way to allow XHR requests to send POST requests in a Rails app is to use the `beforeSend` option to pass along the CSRF token that can be read from the web page’s `meta` tag.

This protects the endpoints from unauthorized requests. You can try this by launching any Rails app that uses Ahoy and sending a cURL request like this one:
```
curl -A "Mozilla/5.0" -X POST -H "Content-Type: application/json" --data '[{"name":"SPAM"}]' http://localhost:3000/ahoy/events
```
You shouldn’t see any events written to your app, and the console should show that you’ve been redirected.

You can also try copying the current CSRF token by viewing the page’s source and sending a cURL request that includes the token, such as:
```
curl -A "Mozilla/5.0" -X POST -H "Content-Type: application/json" -H "X-CSRF-Token: cT8uTZqS0Xlf8lmwJOz4NKlVT1GzmpubJkscD+pFgNCXkDhs7hYq+0G+VWQVX5AvooOuGIa+6FaBpSPIx/+GQA==" --data '[{"name":"SPAM WITH TOKEN“}]’ http://localhost:3000/ahoy/events
```
That shouldn’t work either.

If you set the `filters` variable in the BaseController to its previous value:
```
filters = _process_action_callbacks.map(&:filter) - [:load_authlogic]
```
and if you run the cURL command again, you will see that it can successfully write the spam event to your app.

Fixes #150.