### PR TITLE
allow ahoy.track_visit and ahoy.track_event to recieve blocks

### DIFF
--- a/lib/ahoy/stores/active_record_store.rb
+++ b/lib/ahoy/stores/active_record_store.rb
@@ -12,7 +12,7 @@ module Ahoy
 
         set_visit_properties(visit)
 
-        yield(visit) if block_given?
+        block.call(visit) if block_given?
 
         begin
           visit.save!
@@ -33,7 +33,7 @@ module Ahoy
             e.time = options[:time]
           end
 
-        yield(event) if block_given?
+        block.call(event) if block_given?
 
         begin
           event.save!

--- a/lib/ahoy/stores/active_record_token_store.rb
+++ b/lib/ahoy/stores/active_record_token_store.rb
@@ -13,7 +13,7 @@ module Ahoy
 
         set_visit_properties(visit)
 
-        yield(visit) if block_given?
+        block.call(visit) if block_given?
 
         begin
           visit.save!
@@ -49,7 +49,7 @@ module Ahoy
               e.time = options[:time]
             end
 
-          yield(event) if block_given?
+          block.call(event) if block_given?
 
           event.save!
         end

--- a/lib/ahoy/stores/log_store.rb
+++ b/lib/ahoy/stores/log_store.rb
@@ -9,7 +9,7 @@ module Ahoy
         data[:user_id] = user.id if user
         data[:started_at] = options[:started_at]
 
-        yield(data) if block_given?
+        block.call(data) if block_given?
 
         log_visit(data)
       end
@@ -25,7 +25,7 @@ module Ahoy
         data[:user_id] = user.id if user
         data[:time] = options[:time]
 
-        yield(data) if block_given?
+        block.call(data) if block_given?
 
         log_event(data)
       end

--- a/lib/ahoy/stores/mongoid_store.rb
+++ b/lib/ahoy/stores/mongoid_store.rb
@@ -12,7 +12,7 @@ module Ahoy
 
         set_visit_properties(visit)
 
-        yield(visit) if block_given?
+        block.call(visit) if block_given?
 
         visit.upsert
         geocode(visit)
@@ -29,7 +29,7 @@ module Ahoy
             e.time = options[:time]
           end
 
-        yield(event) if block_given?
+        block.call(event) if block_given?
 
         event.upsert
       end

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -9,7 +9,7 @@ module Ahoy
       @options = options
     end
 
-    def track(name, properties = {}, options = {})
+    def track(name, properties = {}, options = {}, &block)
       if exclude?
         debug "Event excluded"
       else
@@ -18,14 +18,14 @@ module Ahoy
         options[:time] = trusted_time(options[:time])
         options[:id] = ensure_uuid(options[:id] || generate_id)
 
-        @store.track_event(name, properties, options)
+        @store.track_event(name, properties, options, &block)
       end
       true
     rescue => e
       report_exception(e)
     end
 
-    def track_visit(options = {})
+    def track_visit(options = {}, &block)
       if exclude?
         debug "Visit excluded"
       else
@@ -36,7 +36,7 @@ module Ahoy
 
           options[:started_at] ||= Time.zone.now
 
-          @store.track_visit(options)
+          @store.track_visit(options, &block)
         end
       end
       true


### PR DESCRIPTION
This changes the Tracker so that the track_visit and track_event methods may receive blocks
and pass them to the store. Although the store methods of the same name would yield the
visit or event object, they were not passed a block from the Tracker instance.
This change also switches to `block.call(object)` instead of `yield(object)` because the
method signature already instructed the Ruby VM to create a block with the `&block` argument.