### PR TITLE
Also include Ahoy::Controller in ActionController::API subclasses

### DIFF
--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -118,6 +118,7 @@ end
 if defined?(Rails)
   ActiveSupport.on_load(:action_controller) do
     ActionController::Base.send :include, Ahoy::Controller
+    ActionController::API.send :include, Ahoy::Controller if defined?(ActionController::API)
   end
 
   ActiveSupport.on_load(:active_record) do

--- a/lib/ahoy/controller.rb
+++ b/lib/ahoy/controller.rb
@@ -3,8 +3,10 @@ require "request_store"
 module Ahoy
   module Controller
     def self.included(base)
-      base.helper_method :current_visit
-      base.helper_method :ahoy
+      if base.respond_to?(:helper_method)
+        base.helper_method :current_visit
+        base.helper_method :ahoy
+      end
       if base.respond_to?(:before_action)
         base.before_action :set_ahoy_cookies, unless: -> { Ahoy.api_only }
         base.before_action :track_ahoy_visit, unless: -> { Ahoy.api_only }


### PR DESCRIPTION
I needed to use ahoy from an `ActionController::API` subclass (not a subclass of `ActionController::Base`) in my Rails 5 app.