### PR TITLE
Fetch visit using ahoy.visit_token if unique violation error was raised

### DIFF
--- a/lib/ahoy/stores/active_record_token_store.rb
+++ b/lib/ahoy/stores/active_record_token_store.rb
@@ -19,7 +19,8 @@ module Ahoy
           visit.save!
           geocode(visit)
         rescue *unique_exception_classes
-          @visit = visit_model.where(visit_token: ahoy.visit_token).first
+          # reset to nil so subsequent calls to track_event will load visit from DB
+          @visit = nil
         end
       end
 

--- a/lib/ahoy/stores/active_record_token_store.rb
+++ b/lib/ahoy/stores/active_record_token_store.rb
@@ -19,7 +19,7 @@ module Ahoy
           visit.save!
           geocode(visit)
         rescue *unique_exception_classes
-          # do nothing
+          @visit = visit_model.where(visit_token: ahoy.visit_token).first
         end
       end
 


### PR DESCRIPTION
In case of any unique error was raised, we will stay with `@visit` contains an instance w/o ID.
So, all `ahoy.track` calls will raise validation error (visit is missing).