### PR TITLE
Make cookies secure when on https site

### DIFF
--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -124,6 +124,7 @@ module Ahoy
       cookie = {
         value: value
       }
+      cookie[:secure]  = request.protocol =~ /https/
       cookie[:expires] = duration.from_now if duration
       domain = Ahoy.cookie_domain || Ahoy.domain
       cookie[:domain] = domain if domain && use_domain

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -124,7 +124,7 @@ module Ahoy
       cookie = {
         value: value
       }
-      cookie[:secure]  = request.protocol =~ /https/
+      cookie[:secure]  = request.ssl?
       cookie[:expires] = duration.from_now if duration
       domain = Ahoy.cookie_domain || Ahoy.domain
       cookie[:domain] = domain if domain && use_domain


### PR DESCRIPTION
When running on https I would like all cookies to be secure.
This solution works for me. Maybe you would like this to be configurable?