### PR TITLE
Uses a GIN index and the @> operator with postgresql-jsonb

### DIFF
--- a/lib/ahoy/properties.rb
+++ b/lib/ahoy/properties.rb
@@ -25,7 +25,9 @@ module Ahoy
             end
           end
         when /postgres|postgis/
-          if column_type == :jsonb || column_type == :json
+          if column_type == :jsonb
+            relation = relation.where("properties @> ?", properties.to_json)
+          elsif column_type == :json
             properties.each do |k, v|
               relation =
                 if v.nil?

--- a/lib/generators/ahoy/stores/templates/active_record_events_migration.rb
+++ b/lib/generators/ahoy/stores/templates/active_record_events_migration.rb
@@ -15,5 +15,6 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
     add_index :ahoy_events, [:visit_id, :name]
     add_index :ahoy_events, [:user_id, :name]
     add_index :ahoy_events, [:name, :time]
+    <% if @database == "postgresql-jsonb" %>add_index :ahoy_events, :properties, using: 'gin'<% end %>
   end
 end

--- a/test/properties/postgresql_jsonb_test.rb
+++ b/test/properties/postgresql_jsonb_test.rb
@@ -4,6 +4,7 @@ ActiveRecord::Base.establish_connection adapter: "postgresql", database: "ahoy_t
 
 ActiveRecord::Migration.create_table :postgresql_jsonb_events, force: true do |t|
   t.jsonb :properties
+  t.index :properties, using: 'gin'
 end
 
 class PostgresqlJsonbEvent < PostgresqlBase


### PR DESCRIPTION
So, I've been dogged by slow event queries for months now and have been making do by needing them less and going async when possible. Such is life. But I hit on something today: using Postgres with jsonb, I put a GIN index on the properties column of ahoy_events. Then, I tried replacing `where_properties` current implementation
```sql
WHERE properties ->> 'key' = 'value'
```
 with the contains operator as such:
```sql
WHERE properties @> '{"key": "value"}'
```
and saw 2x to 10x improvements in speed.


Incidentally, since `properties @> '{"key": null}'` works just fine, we don't need to handle `v.nil?` differently.

Is there any reason we wouldn't want to take advantage of this Postgres feature?