### PR TITLE
Changes GIN index to jsonb_path_ops expression index

### DIFF
--- a/lib/generators/ahoy/stores/templates/active_record_events_migration.rb
+++ b/lib/generators/ahoy/stores/templates/active_record_events_migration.rb
@@ -15,6 +15,6 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
     add_index :ahoy_events, [:visit_id, :name]
     add_index :ahoy_events, [:user_id, :name]
     add_index :ahoy_events, [:name, :time]
-    <% if @database == "postgresql-jsonb" %>add_index :ahoy_events, :properties, using: 'gin'<% end %>
+    <% if @database == "postgresql-jsonb" && ActiveRecord::VERSION::MAJOR >= 5 %>add_index :ahoy_events, 'properties jsonb_path_ops', using: 'gin'<% end %>
   end
 end


### PR DESCRIPTION
You’re right that an index almost as large as the table is unacceptable. I read a little closer in the Postgres docs and found this beauty:
> Although the jsonb_path_ops operator class supports only queries with the @> operator, it has notable performance advantages over the default operator class jsonb_ops. A jsonb_path_ops index is usually much smaller than a jsonb_ops index over the same data, and the specificity of searches is better, particularly when queries contain keys that appear frequently in the data. ([§8.14.4](https://www.postgresql.org/docs/9.6/static/datatype-json.html#JSON-INDEXING))

Rails 5 added the ability to specify operator classes in schema.rb, so I tried it. Using `jsonb_path_ops` solves the space problem handily. It honestly almost looks too good to be true, but I’m pretty sure I ran the benchmark the same as you.

```
Warming up --------------------------------------
           approach1     1.000  i/100ms
           approach2     1.000  i/100ms
Calculating -------------------------------------
           approach1      2.592  (± 0.0%) i/s -     26.000  in  10.029400s
           approach2     11.237  (± 0.0%) i/s -    113.000  in  10.058112s
```

```
                       relation                        |    size
-------------------------------------------------------+------------
public.ahoy_events                                     | 482 MB
public.index_ahoy_events_on_name                       | 160 MB
public.index_ahoy_events_on_time                       | 136 MB
public.ahoy_events_pkey                                | 107 MB
public.index_ahoy_events_on_properties_jsonb_path_ops  | 21 MB
```

(RE: #272)