### PR TITLE
Adds ability to specify the correct callbacks that should be preserved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.1
+
+- Added ability to define callbacks that should be preserved in Ahoy provided controllers
+
 ## 1.6.0
 
 - Added support for Rails 5.1

--- a/app/controllers/ahoy/base_controller.rb
+++ b/app/controllers/ahoy/base_controller.rb
@@ -1,7 +1,6 @@
 module Ahoy
   class BaseController < ApplicationController
-    # skip all filters except for authlogic
-    filters = _process_action_callbacks.map(&:filter) - [:load_authlogic]
+    filters = _process_action_callbacks.map(&:filter) - Ahoy.preserve_callbacks
     if Rails::VERSION::MAJOR >= 5
       skip_before_action(*filters, raise: false)
       skip_after_action(*filters, raise: false)

--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -89,6 +89,10 @@ module Ahoy
   mattr_accessor :api_only
   self.api_only = false
 
+  mattr_accessor :preserve_callbacks
+  # Preserve Authlogic activation. Users of Authlogic will likely need this to properly obtain current_user.
+  self.preserve_callbacks = [:activate_authlogic]
+
   mattr_accessor :protect_from_forgery
   self.protect_from_forgery = false
 


### PR DESCRIPTION
Moves callbacks to preserve into Ahoy configuration.

Updates the Authlogic callback to its correct name `activate_authlogic` instead of `load_authlogic`.