### PR TITLE
Performance improvement suggestion on visits creation

### DIFF
--- a/lib/ahoy/stores/active_record_token_store.rb
+++ b/lib/ahoy/stores/active_record_token_store.rb
@@ -2,6 +2,7 @@ module Ahoy
   module Stores
     class ActiveRecordTokenStore < BaseStore
       def track_visit(options, &block)
+        return if visit_model.where(visit_token: ahoy.visit_token).exists?
         @visit =
           visit_model.new do |v|
             v.visit_token = ahoy.visit_token


### PR DESCRIPTION
AFAIK every call to the `visits` controller calls `track_visit`, that tries to create a new `Visit` record and raises a `RecordNotUnique` exception. [This comment](https://github.com/ankane/ahoy/issues/66#issuecomment-68659726) confirms that this is the desired behavior.

This change allows to avoid the transaction rollback on every visit. Race conditions are still handled by the unique constraint in the first call(s), but later calls won't need that.

I didn't benchmarked the change, but I think is clear that an `exists?` query to the database is much faster than creating a new model and trying to make a failed insert. As a matter of fact, this change slows the first visit call a little, but improves the rest significantly. As an example, in my app in development mode changes from ~100ms to ~5ms.

Finally, I don't know is this change would have secondary effects, since the received block would not be called anymore, but since the visit would not be saved I think thats should be OK too. If needed, to avoid this the new line could be moved down, just before the `save!` call. Probably, the performance would be very similar, but you will not be rollbacking a database change in every application page view.

What do you think about this change?