### PR TITLE
Fix caching issues when trying to get DOM element's data-section attribute value

### DIFF
--- a/vendor/assets/javascripts/ahoy.js
+++ b/vendor/assets/javascripts/ahoy.js
@@ -2,7 +2,7 @@
  * Ahoy.js
  * Simple, powerful JavaScript analytics
  * https://github.com/ankane/ahoy.js
- * v0.2.2
+ * v0.2.1
  * MIT License
  */
 

--- a/vendor/assets/javascripts/ahoy.js
+++ b/vendor/assets/javascripts/ahoy.js
@@ -2,7 +2,7 @@
  * Ahoy.js
  * Simple, powerful JavaScript analytics
  * https://github.com/ankane/ahoy.js
- * v0.2.1
+ * v0.2.2
  * MIT License
  */
 
@@ -208,7 +208,7 @@
       id: $target.attr("id"),
       "class": $target.attr("class"),
       page: page(),
-      section: $target.closest("*[data-section]").data("section")
+      section: $target.closest("*[data-section]").attr("data-section")
     };
   }
 


### PR DESCRIPTION
### What I did
Instead of using jQuery's `.data` function, use the `.attr` function to prevent caching issue with elements that their data-section is changed dynamically.

#### How to reproduce the issue this solves:
1. Set data-section on any DOM element to some value. 
2. Click on it once.
3. Change it's data-section value to something else. 
4. Click on it again.
5. You will see that the second data-section you are getting in the event is the **old** data-section.

I already use this and it works perfectly.