### PR TITLE
Rails tracker example: store more useful info

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def track_action
-    ahoy.track "Viewed #{controller_name}##{action_name}"
+    ahoy.track "Viewed #{controller_path}##{action_name}", params: request.path_parameters
   end
 end
 ```


### PR DESCRIPTION
`controller_path` also stores the controller's namespace, where `controller_name` wouldn't. So for example `controller_path` would return `admin/users#show` while `controller_name` would return `users#show`.

`request.path_parameters` are any params that Rails parsed in order to route the request, e.g. in the above example it'd include the user ID