### PR TITLE
Add configuration to enable manual mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,20 @@ Exceptions are rescued so analytics do not break your app. Ahoy uses [Safely](ht
 Safely.report_exception_method = ->(e) { Rollbar.error(e) }
 ```
 
+###  Mount Ahoy Manually
+If you have a catch-all route you will need to mount ahoy manually to avoid conflicts.
+Add the following code to the your config/intializers/ahoy.rb.
+
+```ruby
+Ahoy.automount = false
+```
+
+then mount it on your own config/route.rb, before the catch-all route.
+
+```ruby
+mount Ahoy::Engine => "/ahoy"
+```
+
 ## Development
 
 Ahoy is built with developers in mind. You can run the following code in your browser’s console.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
-Rails.application.routes.draw do
-  mount Ahoy::Engine => "/ahoy" if Ahoy.api
+if Ahoy.automount
+  Rails.application.routes.draw do
+    mount Ahoy::Engine => "/ahoy" if Ahoy.api
+  end
 end
 
 Ahoy::Engine.routes.draw do

--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -67,6 +67,9 @@ module Ahoy
   mattr_accessor :token_generator
   self.token_generator = -> { SecureRandom.uuid }
 
+  mattr_accessor :automount
+  self.automount = true
+
   def self.log(message)
     Rails.logger.info { "[ahoy] #{message}" }
   end


### PR DESCRIPTION
Using the proposed solution for #29, I added the configuration to support manual mounting of the engine. 

While there is a solution for the issue of catch-all routes, it results in having Ahoy mounted twice.