### PR TITLE
Slicing search_keyword by 255 characters

### DIFF
--- a/lib/ahoy/visit_properties.rb
+++ b/lib/ahoy/visit_properties.rb
@@ -36,7 +36,7 @@ module Ahoy
 
       {
         referring_domain: (Addressable::URI.parse(referrer).host.first(255) rescue nil),
-        search_keyword: (@@referrer_parser.parse(@referrer)[:term][0..255] rescue nil).presence
+        search_keyword: (@@referrer_parser.parse(@referrer)[:term].first(255) rescue nil).presence
       }
     end
 


### PR DESCRIPTION
The referrer was sliced by 256 chars before.