### PR TITLE
Returns the event object when calling the track method

### DIFF
--- a/lib/ahoy/database_store.rb
+++ b/lib/ahoy/database_store.rb
@@ -24,6 +24,7 @@ module Ahoy
       else
         Ahoy.log "Event excluded since visit not created: #{data[:visit_token]}"
       end
+      event if event
     end
 
     def geocode(data)

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -30,9 +30,9 @@ module Ahoy
           event_id: options[:id] || generate_id
         }.select { |_, v| v }
 
-        @store.track_event(data)
+        event = @store.track_event(data)
       end
-      true
+      event
     rescue => e
       report_exception(e)
     end


### PR DESCRIPTION
Useful for when you want to manually update some fields after calling `ahoy.track "Ran action", request.path_parameters` or if you're using a database without a json field, which would make it difficult to query through a serialized json text column, set a custom field like controllers, or action.