### PR TITLE
Ensure tokens do not contain invalid UTF-8 bytes

### DIFF
--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -273,7 +273,10 @@ module Ahoy
     end
 
     def ensure_token(token)
-      token.to_s.gsub(/[^a-z0-9\-]/i, "").first(64) if token
+      token.
+        to_s.
+        encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '').
+        gsub(/[^a-z0-9\-]/i, "").first(64) if token
     end
 
     def debug(message)

--- a/test/tracker_test.rb
+++ b/test/tracker_test.rb
@@ -1,0 +1,54 @@
+require 'minitest/autorun'
+require 'ahoy/tracker'
+require 'ahoy/base_store'
+require 'active_support'
+require 'active_support/core_ext'
+
+module Ahoy
+  class Store < Ahoy::BaseStore
+  end
+end
+
+module Ahoy
+  mattr_accessor :cookies
+  self.cookies = true
+
+  mattr_accessor :api_only
+  self.api_only = false
+end
+
+module Ahoy
+  class TestTracker < Minitest::Test
+    def test_ensure_token_removes_invalid_utf8_bytes_from_visit_token_cookie
+      mock_request = Struct.new(:cookies, :headers)
+      request = mock_request.new({ 'ahoy_visit' => "bad token\255" }, {})
+      tracker = Tracker.new(request: request)
+
+      assert tracker.visit_token, 'bad token'
+    end
+
+    def test_ensure_token_removes_invalid_utf8_bytes_from_visitor_token_cookie
+      mock_request = Struct.new(:cookies, :headers)
+      request = mock_request.new({ 'ahoy_visitor' => "bad token\255" }, {})
+      tracker = Tracker.new(request: request)
+
+      assert tracker.visitor_token, 'bad token'
+    end
+
+    def test_ensure_token_removes_invalid_utf8_bytes_from_visit_token_header
+      mock_request = Struct.new(:cookies, :headers)
+      request = mock_request.new({}, 'Ahoy-Visit' => "bad token\255")
+      tracker = Tracker.new(request: request)
+
+      assert tracker.visit_token, 'bad token'
+    end
+
+    def test_ensure_token_removes_invalid_utf8_bytes_from_visitor_token_header
+      mock_request = Struct.new(:cookies, :headers)
+      request = mock_request.new({}, 'Ahoy-Visitor' => "bad token\255")
+      tracker = Tracker.new(request: request)
+
+      assert tracker.visitor_token, 'bad token'
+    end
+  end
+end


### PR DESCRIPTION
**Why**: If someone sends a request with an Ahoy Cookie or Header that
contains an invalid UTF-8 byte, the app will raise
`ArgumentError: invalid byte sequence in UTF-8`.

**How**:  Encode the token as UTF-8, and replace any invalid or
undefined bytes with an empty string.