### PR TITLE
Fix ahoy_events index on properties

### DIFF
--- a/lib/generators/ahoy/templates/active_record_migration.rb
+++ b/lib/generators/ahoy/templates/active_record_migration.rb
@@ -49,6 +49,6 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
     end
 
     add_index :ahoy_events, [:name, :time]<% if properties_type == "jsonb" && rails5? %>
-    add_index :ahoy_events, "properties jsonb_path_ops", using: "gin"<% end %>
+    add_index :ahoy_events, [:properties], using: "gin", opclass: "jsonb_path_ops"<% end %>
   end
 end


### PR DESCRIPTION
When I tried to do `rails db:rollback` on Rails 5.2.0 this happened:

    ArgumentError: No indexes found on ahoy_events with the options provided.

This patched fixed it for me.