### PR TITLE
Fix rake db:rollback crash for 'properties jsonb_path_ops' index on Postgres

### DIFF
--- a/lib/generators/ahoy/templates/active_record_migration.rb.tt
+++ b/lib/generators/ahoy/templates/active_record_migration.rb.tt
@@ -49,6 +49,8 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
     end
 
     add_index :ahoy_events, [:name, :time]<% if properties_type == "jsonb" && rails5? %>
-    add_index :ahoy_events, "properties jsonb_path_ops", using: "gin"<% end %>
+    add_index :ahoy_events, 'properties jsonb_path_ops',
+      name: :index_ahoy_events_on_properties_jsonb_path_ops,
+      using: "gin"<% end %>
   end
 end


### PR DESCRIPTION
```
$ rake db:rollback

== 20180920055403 CreateAhoyVisitsAndEvents: reverting ========================
-- remove_index(:ahoy_events, {:column=>"properties jsonb_path_ops"})
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

No indexes found on ahoy_events with the options provided.
```

In my `db/schema.rb`, I had:

```ruby
  create_table "ahoy_events", force: :cascade do |t|
    t.bigint "account_id"
    t.string "name"
    t.jsonb "properties"
    t.datetime "time"
    t.bigint "user_id"
    t.bigint "visit_id"
    t.index ["account_id"], name: "index_ahoy_events_on_account_id"
    t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
    t.index ["properties"], name: "index_ahoy_events_on_properties_jsonb_path_ops", opclass: :jsonb_path_ops, using: :gin
    t.index ["user_id"], name: "index_ahoy_events_on_user_id"
    t.index ["visit_id"], name: "index_ahoy_events_on_visit_id"
  end
```

I fixed the issue by setting an explicit name on the index:

```
    add_index :ahoy_events, 'properties jsonb_path_ops',
      name: :index_ahoy_events_on_properties_jsonb_path_ops,
      using: "gin"
```
