### PR TITLE
Exceptions should always crash in development or test

### DIFF
--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -197,6 +197,7 @@ module Ahoy
     end
 
     def report_exception(e)
+      raise e if Rails.env.development? || Rails.env.test?
       Safely.report_exception(e)
     end
 


### PR DESCRIPTION
It's really difficult to debug any issues when all exceptions are silently ignored. Exceptions should crash the application in development or test.