### PR TITLE
Expose the Job class to the API, so that it can be overwritten

### DIFF
--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -39,6 +39,9 @@ module Ahoy
 
   mattr_accessor :geocode
   self.geocode = true
+  
+  mattr_accessor :geocode_job_class
+  self.geocode_job_class = "Ahoy::GeocodeV2Job"
 
   mattr_accessor :max_content_length
   self.max_content_length = 8192

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -57,7 +57,7 @@ module Ahoy
 
           @store.track_visit(data)
 
-          Ahoy::GeocodeV2Job.perform_later(visit_token, data[:ip]) if Ahoy.geocode
+          Ahoy.geocode_job_class.constantize.perform_later(visit_token, data[:ip]) if Ahoy.geocode
         end
       end
       true


### PR DESCRIPTION
I'd like to use Faktory instead of ActiveJob for handling background tasks. This pull requests makes the job class configurable through the API, by exposing `geocoding_job_class` as a new parameter. Let me know what you think.