### PR TITLE
Use Tracker without controller or request coupling

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This is typically useful for APIs. If your entire Rails app is an API, you can u
 Ahoy.api_only = true
 ```
 
-You can also defer visit tracking to JavaScript. This is useful for preventing bots (that aren’t detected by their user agent) and users with cookies disabled from creating a new visit on each request. `:when_needed` will create visits server-side only when needed by events, and `false` will disable server-side creation completely, discarding events without a visit.
+You can also defer visit tracking to JavaScript. This is useful for preventing bots (that aren’t detected by their user agent) and users with cookies disabled from creating a new visit on each request. `:when_needed` will create visits server-side for events if possible, and `false` will disable server-side creation completely, discarding events without a visit.
 
 ```ruby
 Ahoy.server_side_visits = :when_needed

--- a/app/controllers/ahoy/base_controller.rb
+++ b/app/controllers/ahoy/base_controller.rb
@@ -15,7 +15,7 @@ module Ahoy
     protected
 
     def ahoy
-      @ahoy ||= Ahoy::Tracker.new(controller: self, api: true)
+      @ahoy ||= Ahoy::ControllerTracker.new(self, api: true)
     end
 
     # set proper ttl if cookie generated from JavaScript

--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -15,6 +15,8 @@ require "ahoy/helper"
 require "ahoy/model"
 require "ahoy/query_methods"
 require "ahoy/tracker"
+require "ahoy/request_tracker"
+require "ahoy/controller_tracker"
 require "ahoy/version"
 require "ahoy/visit_properties"
 

--- a/lib/ahoy/controller.rb
+++ b/lib/ahoy/controller.rb
@@ -11,7 +11,7 @@ module Ahoy
     end
 
     def ahoy
-      @ahoy ||= Ahoy::Tracker.new(controller: self)
+      @ahoy ||= Ahoy::ControllerTracker.new(self)
     end
 
     def current_visit

--- a/lib/ahoy/controller_tracker.rb
+++ b/lib/ahoy/controller_tracker.rb
@@ -1,0 +1,27 @@
+module Ahoy
+  class ControllerTracker < RequestTracker
+    def initialize(controller, **options)
+      options[:user_resolver] ||= -> {
+        if Ahoy.user_method.respond_to?(:call)
+          Ahoy.user_method.call(controller)
+        else
+          controller.__send__(Ahoy.user_method)
+        end
+      }
+    
+      options[:exclude_method_resolver] ||= -> {
+        if Ahoy.exclude_method
+          if Ahoy.exclude_method.arity == 1
+            Ahoy.exclude_method.call(controller)
+          else
+            Ahoy.exclude_method.call(controller, controller.request)
+          end
+        else
+          false
+        end
+      }
+    
+      super(controller.request, **options)
+    end
+  end
+end

--- a/lib/ahoy/database_store.rb
+++ b/lib/ahoy/database_store.rb
@@ -13,10 +13,12 @@ module Ahoy
 
     def track_event(data)
       visit = visit_or_create(started_at: data[:time])
-      if visit
+
+      if visit || Ahoy.server_side_visits == :when_needed
         event = event_model.new(slice_data(event_model, data))
         event.visit = visit
-        event.time = visit.started_at if event.time < visit.started_at
+        event.time = visit.started_at if visit && event.time < visit.started_at
+
         begin
           event.save!
         rescue => e

--- a/lib/ahoy/request_tracker.rb
+++ b/lib/ahoy/request_tracker.rb
@@ -1,0 +1,18 @@
+module Ahoy
+  class RequestTracker < Tracker
+    def initialize(request, **options)
+      super(
+        params: {
+          "remote_ip" => request.remote_ip,
+          "user_agent" => request.user_agent,
+          "referrer" => request.referer,
+          "landing_page" => request.original_url
+        }.merge(request.params),
+        headers: request.headers,
+        cookies: request.cookies,
+        cookie_jar: request.cookie_jar,
+        **options
+      )
+    end
+  end
+end

--- a/lib/ahoy/warden.rb
+++ b/lib/ahoy/warden.rb
@@ -1,5 +1,5 @@
 Warden::Manager.after_set_user except: :fetch do |user, auth, _|
   request = ActionDispatch::Request.new(auth.env)
-  ahoy = Ahoy::Tracker.new(request: request)
+  ahoy = Ahoy::RequestTracker.new(request)
   ahoy.authenticate(user)
 end


### PR DESCRIPTION
We are using Ahoy to store statistical data about our system, not analytics data about users. In order for Ahoy to be used for generalized event tracking (such as background jobs), the `controller` and `request` objects need to be decoupled from `Tracker` and `*Store`. Passing the needed values from those objects as a `params` hash allows Ahoy to be used outside the context of the user and request lifecycle.

This PR simply focuses on decoupling by introducing a `params` hash and the idea of "resolver" options to access values that might be specific to a request lifecycle.

The commits on this PR have been separated to help illustrate how the refactor was approached.

Note: The `:when_needed` value is utilized to make a visit optional server-side, allowing events to be created without a visit.

**Example initializer:**

```ruby
class Ahoy::Store < Ahoy::DatabaseStore
end

# set to true for JavaScript tracking
Ahoy.api = false
Ahoy.server_side_visits = :when_needed
Ahoy.track_bots = true
Ahoy.cookie_domain = :all
```

**Example event:**

```ruby
Ahoy::Tracker.new.track('Test event', { prop: 'value' }, { time: Time.current })
```
