### PR TITLE
Add httponly config flag & functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,14 @@ Ahoy::Visit.find_each do |visit|
 end
 ```
 
+### Httponly Cookies
+
+Httponly cookies are disabled by default. To enabled them, do this in your initializer file:
+```ruby
+Ahoy.force_httponly_cookies = true
+```
+
+
 ### Anonymity Sets & Cookies
 
 Ahoy can switch from cookies to [anonymity sets](https://privacypatterns.org/patterns/Anonymity-set). Instead of cookies, visitors with the same IP mask and user agent are grouped together in an anonymity set.

--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -62,6 +62,9 @@ module Ahoy
   mattr_accessor :preserve_callbacks
   self.preserve_callbacks = [:load_authlogic, :activate_authlogic]
 
+  mattr_accessor :force_httponly_cookies
+  self.force_httponly_cookies = false
+
   mattr_accessor :user_method
   self.user_method = lambda do |controller|
     (controller.respond_to?(:current_user, true) && controller.send(:current_user)) || (controller.respond_to?(:current_resource_owner, true) && controller.send(:current_resource_owner)) || nil

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -172,7 +172,8 @@ module Ahoy
       return unless Ahoy.cookies && request
 
       cookie = {
-        value: value
+        value: value,
+        httponly: true
       }
       cookie[:expires] = duration.from_now if duration
       domain = Ahoy.cookie_domain

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -172,9 +172,10 @@ module Ahoy
       return unless Ahoy.cookies && request
 
       cookie = {
-        value: value,
-        httponly: true
+        value: value
       }
+      cookie[:httponly] = true if Ahoy.force_httponly_cookies
+
       cookie[:expires] = duration.from_now if duration
       domain = Ahoy.cookie_domain
       cookie[:domain] = domain if domain && use_domain

--- a/lib/ahoy/version.rb
+++ b/lib/ahoy/version.rb
@@ -1,3 +1,3 @@
 module Ahoy
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
 end


### PR DESCRIPTION
httponly is a cookie attribute that increases security of the application