### PR TITLE
Allow inline geocoding

### DIFF
--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -41,6 +41,9 @@ module Ahoy
   mattr_accessor :geocode
   self.geocode = true
 
+  mattr_accessor :geocode_inline
+  self.geocode_inline = false
+
   mattr_accessor :max_content_length
   self.max_content_length = 8192
 

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -58,7 +58,13 @@ module Ahoy
 
           @store.track_visit(data)
 
-          Ahoy::GeocodeV2Job.perform_later(visit_token, data[:ip]) if Ahoy.geocode && data[:ip]
+          if data[:ip] && Ahoy.geocode
+            if Ahoy.geocode_inline
+              Ahoy::GeocodeV2Job.perform_now(visit_token, data[:ip])
+            else
+              Ahoy::GeocodeV2Job.perform_later(visit_token, data[:ip])
+            end
+          end
         end
       end
       true


### PR DESCRIPTION
When using a local geocoder like GeoIP2, it's inefficient to spawn a background job for this.

This PR adds a `Ahoy.geocode_inline` option which defaults to `false`. When enabled, it will perform the geocoding in-request.