### PR TITLE
Add description of sidekiq queue option

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Change the job queue with:
 Ahoy.job_queue = :low_priority
 ```
 
+If you use Sidekiq, add `ahoy` to queues in the configuration file or add `-q ahoy` as an argument when you start sidekiq.
+
 #### Geocoding Performance
 
 To avoid calls to a remote API, download the [GeoLite2 City database](https://dev.maxmind.com/geoip/geoip2/geolite2/) and configure Geocoder to use it.


### PR DESCRIPTION
When geocoding is on, geolocation data updating is executed via ActiveJob.

The name of queue is not default, but ahoy.
Added description will decrease the gem users' surprise.