### PR TITLE
Update Geocoder config ex. for Heroku buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ And create an initializer at `config/initializers/geocoder.rb` with:
 Geocoder.configure(
   ip_lookup: :geoip2,
   geoip2: {
-    file: Rails.root.join("lib", "GeoLite2-City.mmdb")
+    file: Rails.root.join("db", "GeoLite2-City.mmdb")
   }
 )
 ```


### PR DESCRIPTION
The [linked buildpack](https://github.com/temedica/heroku-buildpack-maxmind-geolite2) in `README.md` downloads and places the database file in the db directory, not the lib directory. Update the example configuration to match.