### PR TITLE
Adding Ahoy.cookie_options to provide support for same site

### DIFF
--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -32,6 +32,9 @@ module Ahoy
 
   mattr_accessor :cookie_domain
 
+  mattr_accessor :cookie_options
+  self.cookie_options = {}
+
   mattr_accessor :server_side_visits
   self.server_side_visits = true
 
@@ -83,9 +86,6 @@ module Ahoy
 
   mattr_accessor :user_agent_parser
   self.user_agent_parser = :device_detector
-
-  mattr_accessor :cookie_options
-  self.cookie_options = {}
 
   mattr_accessor :logger
 

--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -84,6 +84,9 @@ module Ahoy
   mattr_accessor :user_agent_parser
   self.user_agent_parser = :device_detector
 
+  mattr_accessor :cookie_options
+  self.cookie_options = {}
+
   mattr_accessor :logger
 
   def self.log(message)

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -171,8 +171,7 @@ module Ahoy
       # safety net
       return unless Ahoy.cookies && request
 
-      cookie = Ahoy.cookie_options
-      cookie.merge(value: value)
+      cookie = Ahoy.cookie_options.merge(value: value)
       cookie[:expires] = duration.from_now if duration
       domain = Ahoy.cookie_domain
       cookie[:domain] = domain if domain && use_domain

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -171,9 +171,8 @@ module Ahoy
       # safety net
       return unless Ahoy.cookies && request
 
-      cookie = {
-        value: value
-      }
+      cookie = Ahoy.cookie_options
+      cookie.merge(value: value)
       cookie[:expires] = duration.from_now if duration
       domain = Ahoy.cookie_domain
       cookie[:domain] = domain if domain && use_domain


### PR DESCRIPTION
Hey all, first contribution to this repo so let me know if I missed anything. This is to support a new attribute of `Ahoy`: `cookie_options`. This was added to support SameSite, but it was kept open enough to allow for further extension. All of that being said I have a feeling this may be a tad too simple. If that's the case just let me know and I'll get some more work done on it.  