### PR TITLE
Update README to use safer `filtered_parameters`

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def track_action
-    ahoy.track "Ran action", request.path_parameters
+    ahoy.track "Ran action", request.filtered_parameters
   end
 end
 ```


### PR DESCRIPTION
Tracking `path_parameters` reveals potentially sensitive information passed through the URL, such as access tokens. This change updates the README file instructing the user to use [`filtered_parameters`](https://api.rubyonrails.org/classes/ActionDispatch/Http/FilterParameters.html#method-i-filtered_parameters) instead, which replaces any unsafe params with "[FILTERED]", just like in Rails' logs.