### PR TITLE
Update Readme for Collations

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def track_action
-    ahoy.track "Ran action", request.path_parameters
+    ahoy.track "Ran action", request.path_parameters.to_json
   end
 end
 ```


### PR DESCRIPTION
Path parameters have to be serialized to JSON before they can be inserted into the database or the database will run into a Collation issue and not accept values.

The migration `create_ahoy_visits_and_events.rb` line 54 `t.json :properties` only accepts json into the database.. This change is to update documentation to reflect the issue with using the current documentation.

Ran into this issue with mysql2 gem.