### PR TITLE
Allow override eventProperties

### DIFF
--- a/vendor/assets/javascripts/ahoy.js
+++ b/vendor/assets/javascripts/ahoy.js
@@ -298,17 +298,6 @@
     return obj;
   }
 
-  function eventProperties(e) {
-    var target = e.target;
-    return cleanObject({
-      tag: target.tagName.toLowerCase(),
-      id: presence(target.id),
-      "class": presence(target.className),
-      page: page(),
-      section: getClosestSection(target)
-    });
-  }
-
   function getClosestSection(element) {
     for ( ; element && element !== document; element = element.parentNode) {
       if (element.hasAttribute('data-section')) {
@@ -381,6 +370,17 @@
         setReady();
       }
     }
+  }
+
+  ahoy.eventProperties = function(e) {
+    var target = e.target;
+    return cleanObject({
+      tag: target.tagName.toLowerCase(),
+      id: presence(target.id),
+      "class": presence(target.className),
+      page: page(),
+      section: getClosestSection(target)
+    });
   }
 
   ahoy.getVisitId = ahoy.getVisitToken = function () {
@@ -466,7 +466,7 @@
   ahoy.trackClicks = function () {
     onEvent("click", "a, button, input[type=submit]", function (e) {
       var target = e.target;
-      var properties = eventProperties(e);
+      var properties = ahoy.eventProperties(e);
       properties.text = properties.tag == "input" ? target.value : (target.textContent || target.innerText || target.innerHTML).replace(/[\s\r\n]+/g, " ").trim();
       properties.href = target.href;
       ahoy.track("$click", properties);
@@ -475,14 +475,14 @@
 
   ahoy.trackSubmits = function () {
     onEvent("submit", "form", function (e) {
-      var properties = eventProperties(e);
+      var properties = ahoy.eventProperties(e);
       ahoy.track("$submit", properties);
     });
   };
 
   ahoy.trackChanges = function () {
     onEvent("change", "input, textarea, select", function (e) {
-      var properties = eventProperties(e);
+      var properties = ahoy.eventProperties(e);
       ahoy.track("$change", properties);
     });
   };


### PR DESCRIPTION
For my particular case I need to pull off the element more properties than pulled by default (`id`, `className`, `section`). To be more precise, I want to pull whole `dataset`.

The most straightforward way to do so is overriding `eventProperties`, which is used in `trackClicks`, `trackSubmits` and `trackChanges`.

However in its current state I can override `trackClick` and others, but that would be too much of a monkey patch.

I believe making `eventProperties` overridable won't hurt anyone and will improve the options to customize events data.