### PR TITLE
Speed up token retrieval

### DIFF
--- a/lib/ahoy/database_store.rb
+++ b/lib/ahoy/database_store.rb
@@ -53,7 +53,7 @@ module Ahoy
 
     def visit
       unless defined?(@visit)
-        @visit = visit_model.where(visit_token: ahoy.visit_token).first if ahoy.visit_token
+        @visit = visit_model.find_by(visit_token: ahoy.visit_token) if ahoy.visit_token
       end
       @visit
     end


### PR DESCRIPTION
We have about 5 millions visits record in our PostgreSQL 12 db.  After doing various performance analysis on pganalyze and scout I kept seeing a huge performance hit of 1+sec to retrieve visits, google pagespeed complained about my page load time, this surprised me as visit_token is indexed

Compare these two syntaxes and performance
`Visit.where(visit_token: "4208f558-2c45-4d9d-806b-b1bf14194665").first
  Visit Load (1490.7ms)  SELECT  "visits".* FROM "visits" WHERE "visits"."visit_token" = $1 ORDER BY "visits"."id" ASC LIMIT $2  [["visit_token", "4208f558-2c45-4d9d-806b-b1bf14194665"], ["LIMIT", 1]]`

`Visit.find_by(visit_token: "4208f558-2c45-4d9d-806b-b1bf14194665")
  Visit Load (5.2ms)  SELECT  "visits".* FROM "visits" WHERE "visits"."visit_token" = $1 LIMIT $2  [["visit_token", "4208f558-2c45-4d9d-806b-b1bf14194665"], ["LIMIT", 1]]`

Calling where and first uses the primary key id and causes a full index scan

Limit (cost=0.43..51.73 rows=1 width=651) (actual time=1980.810..1980.813 rows=0 loops=1)
--
-> Index Scan using visits_pkey on visits (cost=0.43..1386068.52 rows=27021 width=651) (actual time=1980.808..1980.808 rows=0 loops=1)
Filter: ((visit_token)::text = '4208f558-2c45-4d9d-806b-b1bf14194665'::text)
Rows Removed by Filter: 5399602
Planning Time: 0.191 ms
Execution Time: 1981.177 ms

Since Rails offers find_by, why not use it which results in a fraction of the query cost

The same query using just find_by

Limit (cost=0.00..3.86 rows=1 width=651) (actual time=0.037..0.038 rows=0 loops=1)
--
-> Index Scan using index_visits_on_visit_token on visits (cost=0.00..104428.87 rows=27021 width=651) (actual time=0.035..0.035 rows=0 loops=1)
Index Cond: ((visit_token)::text = '4208f558-2c45-4d9d-806b-b1bf14194665'::text)
Planning Time: 0.338 ms
Execution Time: 0.131 ms


find_by has been around since Rails 4 so fairly safe to use 

