### PR TITLE
Update README to provide more accurate geocoding info

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,10 +350,10 @@ Safely.report_exception_method = ->(e) { Rollbar.error(e) }
 
 Ahoy uses [Geocoder](https://github.com/alexreisner/geocoder) for geocoding. We recommend configuring [local geocoding](#local-geocoding) or [load balancer geocoding](#load-balancer-geocoding) so IP addresses are not sent to a 3rd party service. If you do use a 3rd party service and adhere to GDPR, be sure to add it to your subprocessor list. If Ahoy is configured to [mask IPs](#ip-masking), the masked IP is used (this can reduce accuracy but is better for privacy).
 
-To enable geocoding, update `config/initializers/ahoy.rb`:
+Geocoding is enabled by default; to disable geocoding, update `config/initializers/ahoy.rb`:
 
 ```ruby
-Ahoy.geocode = true
+Ahoy.geocode = false
 ```
 
 Geocoding is performed in a background job so it doesn’t slow down web requests. The default job queue is `:ahoy`. Change this with:


### PR DESCRIPTION
Geocoding is on by default: 
https://github.com/ankane/ahoy/blob/2515f80d50657014c1531dac05e1f5b4045cb47e/lib/ahoy.rb#L46-L47

But the current README makes it seem like it's not.   We noticed this when we had 10's of thousands of geocode jobs in our sidekiq queue 😂