### PR TITLE
Add Documentation On Disabling Cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ You can also defer visit tracking to JavaScript. This is useful for preventing b
 Ahoy.server_side_visits = :when_needed
 ```
 
+If you need to disable setting ahoy cookies in a controller, you can do so with:
+
+```ruby
+skip_before_action :set_ahoy_cookies
+```
+
 ### Events
 
 Each event has a `name` and `properties`. There are several ways to track events.


### PR DESCRIPTION
Thank you for this gem! This adds documentation on disabling the before action for setting cookies for particular Rails controller/action. I have a Rails app that serves some API routes and some full MVC routes, in which case I'd rather not set `Ahoy.api_only`. Hoping this helps someone else looking for the same thing!

Let me know what you think about the placement in the README. Most likely this would always be paired with

```ruby
skip_before_action :track_ahoy_visit
```

but I didn't want to emphasize this method since it's probably not as common of a use case.