### PR TITLE
Add CockroachDB on postgres loop, as they are functionally the same here.

### DIFF
--- a/lib/ahoy/query_methods.rb
+++ b/lib/ahoy/query_methods.rb
@@ -59,7 +59,7 @@ module Ahoy
             quoted_prop = connection.quote("$.#{prop}")
             relation = relation.group("JSON_UNQUOTE(JSON_EXTRACT(properties, #{quoted_prop}))")
           end
-        when /postgres|postgis/
+        when /postgres|postgis|cockroachdb/
           # convert to jsonb to fix
           # could not identify an equality operator for type json
           # and for text columns

--- a/lib/ahoy/query_methods.rb
+++ b/lib/ahoy/query_methods.rb
@@ -16,7 +16,7 @@ module Ahoy
           where(properties.to_h { |k, v| ["properties.#{k}", v] })
         when /mysql/
           where("JSON_CONTAINS(properties, ?, '$') = 1", properties.to_json)
-        when /postgres|postgis/
+        when /postgres|postgis|cockroachdb/
           case columns_hash["properties"].type
           when :hstore
             properties.inject(all) do |relation, (k, v)|


### PR DESCRIPTION
You can feel free to test with a serverless crdb cluster which is free, 
https://www.cockroachlabs.com/get-started-cockroachdb/
add gem "activerecord-cockroachdb-adapter", "~> 6.1"
install their certs to your local .postgres with their instructions and use url: with their connection string on database.yml

The CRDB adapter is pretty compliant with postgres (https://www.cockroachlabs.com/docs/stable/jsonb.html)