### PR TITLE
Update Active Record Migration template to use primary key configuration

### DIFF
--- a/lib/generators/ahoy/templates/active_record_migration.rb.tt
+++ b/lib/generators/ahoy/templates/active_record_migration.rb.tt
@@ -1,6 +1,9 @@
 class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version %>
   def change
-    create_table :ahoy_visits do |t|
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :ahoy_visits, id: primary_key_type do |t|
       t.string :visit_token
       t.string :visitor_token
 
@@ -8,7 +11,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
       # simply remove any you don't want
 
       # user
-      t.references :user
+      t.references :user, type: foreign_key_type
 
       # standard
       t.string :ip
@@ -46,9 +49,9 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
 
     add_index :ahoy_visits, :visit_token, unique: true
 
-    create_table :ahoy_events do |t|
-      t.references :visit
-      t.references :user
+    create_table :ahoy_events, id: primary_key_type do |t|
+      t.references :visit, type: foreign_key_type
+      t.references :user, type: foreign_key_type
 
       t.string :name
       t.<%= properties_type %> :properties
@@ -58,5 +61,15 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
     add_index :ahoy_events, [:name, :time]<% if properties_type == "jsonb" %><% if rails52? %>
     add_index :ahoy_events, :properties, using: :gin, opclass: :jsonb_path_ops<% else %>
     add_index :ahoy_events, "properties jsonb_path_ops", using: "gin"<% end %><% end %>
+  end
+
+  private
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
   end
 end


### PR DESCRIPTION
- Updated the Active Record Migration template to use the primary key configuration.
  - I noticed if you had `uuid` set as the primary key, the out of the box generated migrations did not exactly work as expected. For example, `user_id` was simply `null` for everything in the database since it couldn't carry on with a `uuid` in a `bigint` column.
- The current implementation merely copies the rails implementation for things like the `action_text_rich_texts` table, see [this rails commit](https://github.com/rails/rails/blob/b02c77f1d565af14a5c2774a085e86cc30d9f369/actiontext/db/migrate/20180528164100_create_action_text_tables.rb#L3-L24).
- I didn't quite capture any particular specs to update except yes, the existing generator specs pass. It certainly works on my machine 🙃 