### PR TITLE
Add support for additional values from the controller

### DIFF
--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -71,6 +71,16 @@ module Ahoy
     (controller.respond_to?(:current_user, true) && controller.send(:current_user)) || (controller.respond_to?(:current_resource_owner, true) && controller.send(:current_resource_owner)) || nil
   end
 
+  mattr_accessor :additional_event_values_method
+  self.additional_event_values_method = lambda do |controller|
+    (controller.respond_to?(:ahoy_event_values, true) && controller.send(:ahoy_event_values))|| {}
+  end
+
+  mattr_accessor :additional_visit_values_method
+  self.additional_visit_values_method = lambda do |controller|
+    (controller.respond_to?(:ahoy_visit_values, true) && controller.send(:ahoy_visit_values))|| {}
+  end
+
   mattr_accessor :exclude_method
 
   mattr_accessor :track_bots

--- a/lib/ahoy/base_store.rb
+++ b/lib/ahoy/base_store.rb
@@ -22,17 +22,15 @@ module Ahoy
     end
 
     def user
-      @user ||= begin
-        if Ahoy.user_method.respond_to?(:call)
-          if Ahoy.user_method.arity == 1
-            Ahoy.user_method.call(controller)
-          else
-            Ahoy.user_method.call(controller, request)
-          end
-        else
-          controller.send(Ahoy.user_method) if controller.respond_to?(Ahoy.user_method, true)
-        end
-      end
+      @user ||= defineable_ahoy_method(:user_method)
+    end
+
+    def additional_event_values
+      @additional_event_values ||= defineable_ahoy_method(:additional_event_values_method)
+    end
+
+    def additional_visit_values
+      @additional_visit_values ||= defineable_ahoy_method(:additional_visit_values_method)
     end
 
     def exclude?
@@ -96,6 +94,20 @@ module Ahoy
 
     def ahoy
       @ahoy ||= @options[:ahoy]
+    end
+
+    private
+
+    def defineable_ahoy_method(name)
+      if Ahoy.send(name).respond_to?(:call)
+        if Ahoy.send(name).arity == 1
+          Ahoy.send(name).call(controller)
+        else
+          Ahoy.send(name).call(controller, request)
+        end
+      else
+        controller.send(Ahoy.send(name)) if controller.respond_to?(Ahoy.send(name), true)
+      end
     end
   end
 end

--- a/lib/ahoy/database_store.rb
+++ b/lib/ahoy/database_store.rb
@@ -1,7 +1,9 @@
 module Ahoy
   class DatabaseStore < BaseStore
     def track_visit(data)
-      @visit = visit_model.create!(slice_data(visit_model, data))
+      @visit = visit_model.new(slice_data(visit_model, data))
+      @visit.assign_attributes(additional_visit_values)
+      @visit.save!
     rescue => e
       raise e unless unique_exception?(e)
 
@@ -15,6 +17,7 @@ module Ahoy
       visit = visit_or_create(started_at: data[:time])
       if visit
         event = event_model.new(slice_data(event_model, data))
+        event.assign_attributes(additional_event_values)
         event.visit = visit
         event.time = visit.started_at if event.time < visit.started_at
         begin
@@ -43,6 +46,7 @@ module Ahoy
     def authenticate(_)
       if visit && visit.respond_to?(:user) && !visit.user
         begin
+          visit.assign_attributes(additional_visit_values)
           visit.user = user
           visit.save!
         rescue ActiveRecord::AssociationTypeMismatch


### PR DESCRIPTION
As we look at tracking events, our system needs to records more than just user and request details. We need to know the team the user is on and the company account that they're using.

This change allows you to specify those values in the controller like so:

```ruby
class ApplicationController < ActionController::Base
  ...
  def ahoy_visit_values
    { team_id: current_team_id, account: Apartment::Tenant.current }
  end

  def ahoy_event_values
    { team_id: current_team_id, account: Apartment::Tenant.current }
  end
end
```

The additional values need to map to attributes on the event and visit objects.

To implement this, I first looked at using the methods in the tracker.rb file. It felt like changing the data that was passed to track_visit or track_event would make sense. But, then I realized that you're adding user through the data store via the controller and decided that was a more reliable way to do it so I moved it there.

I couldn't figure out the best way to test this given that way that you have the tests setup, but I'm more than happy to put more effort in to add tests and get this ready to merge if you think it's worth adding.