### PR TITLE
Allow to pass :user to Ahoy::Store through Ahoy::Tracker

### DIFF
--- a/lib/ahoy/base_store.rb
+++ b/lib/ahoy/base_store.rb
@@ -3,6 +3,7 @@ module Ahoy
     attr_writer :user
 
     def initialize(options)
+      @user = options[:user]
       @options = options
     end
 

--- a/test/tracker_test.rb
+++ b/test/tracker_test.rb
@@ -35,4 +35,20 @@ class TrackerTest < Minitest::Test
     event = Ahoy::Event.last
     assert_equal user.id, event.user_id
   end
+
+  def test_user_option_with_user_usage_in_store
+    Ahoy::Store.define_method(:track_event) do |data|
+      data[:properties][:user_prop] = user.try(:user_prop)
+      super(data)
+    end
+
+    user = OpenStruct.new(id: 123, user_prop: 42)
+    ahoy = Ahoy::Tracker.new(user: user)
+    ahoy.track('Some event', some_prop: true)
+
+    event = Ahoy::Event.last
+    assert_equal user.user_prop, event.properties['user_prop']
+  ensure
+    Ahoy::Store.remove_method :track_event
+  end
 end


### PR DESCRIPTION
Hello @ankane, thanks for the gem.

So, we can pass `:user` directly to `Ahoy::Tracker`, but, unfortunately, it not defines one in `Ahoy::Store`.  
This request fixes that.

This can be useful, for example, when we track some events asynchronously, without `:controller`, and with some additional user's parameters usage in `Ahoy::Store#track_event`.