### PR TITLE
Adds the ability to opt in to visitor cookie renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,16 @@ Set other [cookie options](https://api.rubyonrails.org/classes/ActionDispatch/Co
 Ahoy.cookie_options = {same_site: :lax}
 ```
 
+The `ahoy_visit` cookie will automatically renew with each request and you can opt-in to the same
+behavior for the `ahoy_visitor` token using:
+
+```ruby
+Ahoy.renew_vistor_token_each_request = true
+```
+
+When enabled, the `ahoy_visitor` cookie will have its expiration set to `Ahoy.visitor_duration`
+from the time of the request. 
+
 You can also [disable cookies](#anonymity-sets--cookies)
 
 ### Token Generation

--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -27,6 +27,9 @@ module Ahoy
   mattr_accessor :visitor_duration
   self.visitor_duration = 2.years
 
+  mattr_accessor :renew_vistor_token_each_request
+  self.renew_vistor_token_each_request = false
+
   def self.cookies=(value)
     if value == false
       # TODO add Mongoid instructions

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -111,7 +111,7 @@ module Ahoy
     end
 
     def set_visitor_cookie
-      if new_visitor?
+      if new_visitor? || Ahoy.renew_vistor_token_each_request
         set_cookie("ahoy_visitor", visitor_token, Ahoy.visitor_duration)
       end
     end


### PR DESCRIPTION
Hi there! As I explained in the issue I posted about this yesterday, it seems logical to me that when someone visits your site, you would want to extend their visitor token along with the visit token.

Without doing so, you could have a point in time where a frequent user of your site is assigned a new `visitor_token`. If your use-case leans on `visitor_token` to connect the actions of a user, this break in continuity could be problematic.

Certainly open to feedback or thoughts on why this might not be the ideal default configuration.

As always, thanks so much for Ahoy!