### PR TITLE
Fix "uninitialized constant Ahoy::ActiveJob" for Rails applications that do not contain an ActiveJob

### DIFF
--- a/app/jobs/ahoy/geocode_v2_job.rb
+++ b/app/jobs/ahoy/geocode_v2_job.rb
@@ -1,31 +1,36 @@
 module Ahoy
-  class GeocodeV2Job < ActiveJob::Base
-    queue_as { Ahoy.job_queue }
+  if defined?(ActiveJob) && defined?(ActiveJob::Base)
+    class GeocodeV2Job < ActiveJob::Base
+      queue_as { Ahoy.job_queue }
 
-    def perform(visit_token, ip)
-      location =
-        begin
-          Geocoder.search(ip).first
-        rescue NameError
-          raise "Add the geocoder gem to your Gemfile to use geocoding"
-        rescue => e
-          Ahoy.log "Geocode error: #{e.class.name}: #{e.message}"
-          nil
+      def perform(visit_token, ip)
+        location =
+            begin
+              Geocoder.search(ip).first
+            rescue NameError
+              raise "Add the geocoder gem to your Gemfile to use geocoding"
+            rescue => e
+              Ahoy.log "Geocode error: #{e.class.name}: #{e.message}"
+              nil
+            end
+
+        if location && location.country.present?
+          data = {
+              country: location.country,
+              country_code: location.try(:country_code).presence,
+              region: location.try(:state).presence,
+              city: location.try(:city).presence,
+              postal_code: location.try(:postal_code).presence,
+              latitude: location.try(:latitude).presence,
+              longitude: location.try(:longitude).presence
+          }
+
+          Ahoy::Tracker.new(visit_token: visit_token).geocode(data)
         end
-
-      if location && location.country.present?
-        data = {
-          country: location.country,
-          country_code: location.try(:country_code).presence,
-          region: location.try(:state).presence,
-          city: location.try(:city).presence,
-          postal_code: location.try(:postal_code).presence,
-          latitude: location.try(:latitude).presence,
-          longitude: location.try(:longitude).presence
-        }
-
-        Ahoy::Tracker.new(visit_token: visit_token).geocode(data)
       end
+    end
+  else
+    class GeocodeV2Job
     end
   end
 end


### PR DESCRIPTION
Hi,

Thank you for this useful gem.

For Rails applications that do not contain an ActiveJob, "uninitialized constant Ahoy::ActiveJob" error will occur. To avoid this error, I have added small code to check if an ActiveJob is already defined before defining an Ahoy::GeocodeV2Job.

Such a Rails application can be created by adding the minimal option to the rails new command (rails new --minimal).

I think this code is not smart. I have no problem if you close this PR and you add your better code. Also, I have already made this modification to my application, so if you think this PR is unnecessary or not for everyone, then feel free to close this PR.