### PR TITLE
Introduce `Ahoy::Tracker#with_store` to temporarily swap stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Introduce `Ahoy::Tracker#with_store` to temporarily swap stores
+
 ## 5.0.2 (2023-10-05)
 
 - Excluded visits from Rails health check

--- a/README.md
+++ b/README.md
@@ -587,6 +587,14 @@ end
 
 Data stores are designed to be highly customizable so you can scale as you grow. Check out [examples](docs/Data-Store-Examples.md) for Kafka, RabbitMQ, Fluentd, NATS, NSQ, and Amazon Kinesis Firehose.
 
+To temporarily switch to another store, call `ahoy.with_store(store_class, &block)`:
+
+```ruby
+ahoy.with_store Ahoy::CustomStore do |custom_store|
+  # use a different store
+end
+```
+
 ### Track Additional Data
 
 ```ruby

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -4,7 +4,7 @@ module Ahoy
   class Tracker
     UUID_NAMESPACE = "a82ae811-5011-45ab-a728-569df7499c5f"
 
-    attr_reader :request, :controller
+    attr_reader :request, :controller, :store
 
     def initialize(**options)
       @store = Ahoy::Store.new(options.merge(ahoy: self))
@@ -150,6 +150,18 @@ module Ahoy
         @exclude = @store.exclude?
       end
       @exclude
+    end
+
+    def with_store(store, &block)
+      if store.is_a?(Class)
+        store = store.new(@store.instance_variable_get(:@options))
+      end
+
+      @store, original = store, @store
+
+      @store.yield_self(&block)
+    ensure
+      @store = original
     end
 
     protected

--- a/test/tracker_test.rb
+++ b/test/tracker_test.rb
@@ -49,4 +49,18 @@ class TrackerTest < Minitest::Test
     event = Ahoy::Event.last
     assert_equal user.user_prop, event.properties["user_prop"]
   end
+
+  def test_with_store
+    other_store = Class.new(Ahoy::BaseStore)
+    user = OpenStruct.new(id: 123, user_prop: 42)
+    ahoy = Ahoy::Tracker.new(user: user)
+
+    assert_kind_of Ahoy::Store, ahoy.store
+
+    ahoy.with_store other_store do |store|
+      assert_kind_of other_store, store
+      assert_kind_of other_store, ahoy.store
+      assert_equal ahoy.store, store
+    end
+  end
 end


### PR DESCRIPTION
To temporarily switch to another store, call
`ahoy.with_store(store_class, &block)`:

```ruby
ahoy.with_store Ahoy::CustomStore do |custom_store|
  # use a different store
end
```