### PR TITLE
Pass `data` to `Ahoy::DatabaseStore#{event,visit}_model`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Pass `data` to `Ahoy::DatabaseStore#visit_model` and `Ahoy::DatabaseStore#event_model`
+
 ## 5.0.2 (2023-10-05)
 
 - Excluded visits from Rails health check

--- a/README.md
+++ b/README.md
@@ -621,11 +621,11 @@ end
 
 ```ruby
 class Ahoy::Store < Ahoy::DatabaseStore
-  def visit_model
+  def visit_model(**data)
     MyVisit
   end
 
-  def event_model
+  def event_model(**data)
     MyEvent
   end
 end


### PR DESCRIPTION
By accepting any available `data` values, the `visit_model` and `event_model` methods can incorporate that information when determining the models to track with.