### PR TITLE
Call `ahoy.reset` during Warden `before_logout` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add `before_logout` hook to Warden that calls `ahoy.reset`
+
 ## 5.0.2 (2023-10-05)
 
 - Excluded visits from Rails health check

--- a/README.md
+++ b/README.md
@@ -212,12 +212,18 @@ visitable :sign_up_visit
 
 ### Users
 
-Ahoy automatically attaches the `current_user` to the visit. With [Devise](https://github.com/heartcombo/devise), it attaches the user even if they sign in after the visit starts.
+Ahoy automatically attaches the `current_user` to the visit. With [Devise](https://github.com/heartcombo/devise), it attaches the user even if they sign in after the visit starts. It also resets the tracker's associated user after they sign out.
 
 With other authentication frameworks, add this to the end of your sign in method:
 
 ```ruby
 ahoy.authenticate(user)
+```
+
+Add this to the end of your sign out method:
+
+```ruby
+ahoy.reset
 ```
 
 To see the visits for a given user, create an association:

--- a/lib/ahoy/warden.rb
+++ b/lib/ahoy/warden.rb
@@ -3,3 +3,9 @@ Warden::Manager.after_set_user except: :fetch do |user, auth, _|
   ahoy = Ahoy::Tracker.new(request: request)
   ahoy.authenticate(user)
 end
+
+Warden::Manager.before_logout do |_, auth, _|
+  request = ActionDispatch::Request.new(auth.env)
+  ahoy = Ahoy::Tracker.new(request: request)
+  ahoy.reset
+end


### PR DESCRIPTION
In addition to the `after_set_user` hook, the `Warden::Manager` also supports a [before_logout][] hook.

This commit integrates with that hook to call `ahoy.reset` so that subsequent visits will be anonymous, and subsequent authenticated sessions will create a new Visit.

[before_logout]: https://www.rubydoc.info/gems/warden/1.2.6/Warden/Hooks#before_logout-instance_method