### PR TITLE
Infer OS Version from User Agent string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Infer OS version from User Agent string when available
+
 ## 5.0.2 (2023-10-05)
 
 - Excluded visits from Rails health check

--- a/lib/ahoy/visit_properties.rb
+++ b/lib/ahoy/visit_properties.rb
@@ -59,6 +59,7 @@ module Ahoy
         {
           browser: client.name,
           os: client.os_name,
+          os_version: client.os_full_version,
           device_type: device_type
         }
       else
@@ -89,6 +90,7 @@ module Ahoy
         {
           browser: agent.name,
           os: agent.os.name,
+          os_version: agent.os.version,
           device_type: device_type
         }
       end

--- a/test/visit_properties_test.rb
+++ b/test/visit_properties_test.rb
@@ -37,6 +37,7 @@ class VisitPropertiesTest < ActionDispatch::IntegrationTest
     assert_equal user_agent, visit.user_agent
     assert_equal "Firefox", visit.browser
     assert_equal "Mac", visit.os
+    assert_equal "10.15", visit.os_version
     assert_equal "Desktop", visit.device_type
   end
 
@@ -49,6 +50,7 @@ class VisitPropertiesTest < ActionDispatch::IntegrationTest
       assert_equal user_agent, visit.user_agent
       assert_equal "Firefox", visit.browser
       assert_equal "Mac OS X", visit.os
+      assert_equal "10.15", visit.os_version
       assert_equal "Desktop", visit.device_type
     end
   end


### PR DESCRIPTION
When available, infer the OS version. Through `DeviceDetector`, invoke `.os_full_version`. Through legacy means, invoce `os.version`