### PR TITLE
Allow cookies if consent given

### DIFF
--- a/lib/ahoy.rb
+++ b/lib/ahoy.rb
@@ -62,6 +62,8 @@ module Ahoy
   mattr_reader :cookies
   self.cookies = true
 
+  mattr_accessor :cookies_method
+
   # TODO deprecate in favor of cookie_options
   mattr_accessor :cookie_domain
 

--- a/lib/ahoy/controller.rb
+++ b/lib/ahoy/controller.rb
@@ -18,7 +18,7 @@ module Ahoy
     end
 
     def set_ahoy_cookies
-      if Ahoy.cookies?
+      if ahoy.cookies?
         ahoy.set_visitor_cookie
         ahoy.set_visit_cookie
       else
@@ -30,9 +30,9 @@ module Ahoy
     def track_ahoy_visit
       defer = Ahoy.server_side_visits != true
 
-      if defer && !Ahoy.cookies?
+      if defer && !ahoy.cookies?
         # avoid calling new_visit?, which triggers a database call
-      elsif !Ahoy.cookies? && ahoy.exclude?
+      elsif !ahoy.cookies? && ahoy.exclude?
         # avoid calling new_visit?, which triggers a database call
         # may or may not be a new visit
         Ahoy.log("Request excluded")

--- a/lib/ahoy/database_store.rb
+++ b/lib/ahoy/database_store.rb
@@ -56,7 +56,7 @@ module Ahoy
         if ahoy.send(:existing_visit_token) || ahoy.instance_variable_get(:@visit_token)
           # find_by raises error by default with Mongoid when not found
           @visit = visit_model.where(visit_token: ahoy.visit_token).take if ahoy.visit_token
-        elsif !Ahoy.cookies? && ahoy.visitor_token
+        elsif !ahoy.cookies? && ahoy.visitor_token
           @visit = visit_model.where(visitor_token: ahoy.visitor_token).where(started_at: Ahoy.visit_duration.ago..).order(started_at: :desc).first
         else
           @visit = nil

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -76,6 +76,8 @@ module Ahoy
     def authenticate(user)
       if exclude?
         debug "Authentication excluded"
+      elsif !cookies?
+        debug "Authentication not possible for anonymity set"
       else
         @store.user = user
 


### PR DESCRIPTION
Hi @ankane,

I had this ideia, to allow cookies if consent given.

In the first visit, the visit is not linked to the user, and data is anonymous.
When the user accepts analytics consent, then we can create a new visit that is automatically linked to the user.

Let me know if it makes sense. Also can try to add tests, etc.