### PR TITLE
Fix `NoMethodError` when no request and `cookies == :none`

### DIFF
--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -241,7 +241,9 @@ module Ahoy
     end
 
     def visitor_anonymity_set
-      @visitor_anonymity_set ||= Digest::UUID.uuid_v5(UUID_NAMESPACE, ["visitor", Ahoy.mask_ip(request.remote_ip), request.user_agent].join("/"))
+      @visitor_anonymity_set ||= Digest::UUID.uuid_v5(
+        UUID_NAMESPACE, ["visitor", Ahoy.mask_ip(request.remote_ip), request.user_agent].join("/")
+      ) if request
     end
 
     def visit_cookie

--- a/test/tracker_test.rb
+++ b/test/tracker_test.rb
@@ -25,6 +25,18 @@ class TrackerTest < Minitest::Test
     assert_nil event.user_id
   end
 
+  def test_no_cookies_no_request
+    with_options(cookies: :none) do
+      ahoy = Ahoy::Tracker.new
+      ahoy.track("Some event", some_prop: true)
+    end
+
+    event = Ahoy::Event.last
+    assert_equal "Some event", event.name
+    assert_equal({"some_prop" => true}, event.properties)
+    assert_nil event.user_id
+  end
+
   def test_user_option
     user = OpenStruct.new(id: 123)
     ahoy = Ahoy::Tracker.new(user: user)


### PR DESCRIPTION
When tracking with no request,

```
Ahoy.cookies = :none
Ahoy::Tracker.new.track_event(:would_fail)
```

would raise `NoMethodError: undefined method 'remote_ip' for nil`. Since we explicitly don't have a `request`, allow `visitor_token_helper` [to fall back on](https://github.com/ankane/ahoy/pull/554/files#diff-02fe38c4271c899c103138e118d9dc32962cd1e6689e6755eeba2d3a1bf581f5R219-R220) `generate_id` by returning `nil` from `visitor_anonymity_set`
when there is no `request`.