### PR TITLE
Add load hooks for controllers

### DIFF
--- a/app/controllers/ahoy/base_controller.rb
+++ b/app/controllers/ahoy/base_controller.rb
@@ -39,5 +39,7 @@ module Ahoy
         render plain: "Payload too large\n", status: :payload_too_large
       end
     end
+
+    ActiveSupport.run_load_hooks(:ahoy_base_controller, self)
   end
 end

--- a/app/controllers/ahoy/events_controller.rb
+++ b/app/controllers/ahoy/events_controller.rb
@@ -36,5 +36,7 @@ module Ahoy
       end
       render json: {}
     end
+
+    ActiveSupport.run_load_hooks(:ahoy_events_controller, self)
   end
 end

--- a/app/controllers/ahoy/visits_controller.rb
+++ b/app/controllers/ahoy/visits_controller.rb
@@ -11,5 +11,7 @@ module Ahoy
         visitor_id: ahoy.visitor_token
       }
     end
+
+    ActiveSupport.run_load_hooks(:ahoy_visits_controller, self)
   end
 end


### PR DESCRIPTION
In order to safely extend the code in ahoy controllers, it would be convenient to run load hooks similar to how Rails does this.