### PR TITLE
Add return of event in track method

### DIFF
--- a/lib/ahoy/database_store.rb
+++ b/lib/ahoy/database_store.rb
@@ -19,6 +19,7 @@ module Ahoy
         event.time = visit.started_at if event.time < visit.started_at
         begin
           event.save!
+          event
         rescue => e
           raise e unless unique_exception?(e)
         end

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -31,7 +31,6 @@ module Ahoy
 
         @store.track_event(data)
       end
-      true
     rescue => e
       report_exception(e)
     end

--- a/test/tracker_test.rb
+++ b/test/tracker_test.rb
@@ -36,6 +36,12 @@ class TrackerTest < Minitest::Test
     assert_equal user.id, event.user_id
   end
 
+  def test_track_return_value
+    ahoy = Ahoy::Tracker.new
+    event = ahoy.track("Some event", some_prop: true)
+    assert_instance_of Ahoy::Event, event
+  end
+
   def test_user_option_in_store
     user = Struct.new(:id, :user_prop).new(123, 42)
     ahoy = Ahoy::Tracker.new(user: user)


### PR DESCRIPTION
Hi, we need get access to the created event. What do you think if there https://github.com/ankane/ahoy/blob/17d977db691d7549040b3b35b71dbd89ee4e24f3/lib/ahoy/database_store.rb#L20-L21

will be instead?

```ruby
        begin
          event.save!
          event
```

or at least to assign last tracked event somewhere to avoid making request to the DB.