### PR TITLE
Fix aborted transaction when a duplicate visit is rescued on Postgres

### DIFF
--- a/lib/ahoy/database_store.rb
+++ b/lib/ahoy/database_store.rb
@@ -1,7 +1,9 @@
 module Ahoy
   class DatabaseStore < BaseStore
     def track_visit(data)
-      @visit = visit_model.create!(slice_data(visit_model, data))
+      visit = visit_model.new(slice_data(visit_model, data))
+      save_record!(visit)
+      @visit = visit
     rescue => e
       raise e unless unique_exception?(e)
 
@@ -18,7 +20,7 @@ module Ahoy
         event.visit = visit
         event.time = visit.started_at if event.time < visit.started_at
         begin
-          event.save!
+          save_record!(event)
         rescue => e
           raise e unless unique_exception?(e)
         end
@@ -30,7 +32,7 @@ module Ahoy
     def geocode(data)
       visit_token = data.delete(:visit_token)
       data = slice_data(visit_model, data)
-      if defined?(Mongoid::Document) && visit_model < Mongoid::Document
+      if mongoid?(visit_model)
         # upsert since visit might not be found due to eventual consistency
         visit_model.where(visit_token: visit_token).find_one_and_update({"$set": data}, {upsert: true})
       elsif visit
@@ -72,6 +74,28 @@ module Ahoy
     end
 
     protected
+
+    # Postgres aborts the entire transaction when a statement fails, so rescuing
+    # the unique violation is not enough when the caller is already inside a
+    # transaction -- the `visitable` macro creates visits from a before_create
+    # hook, and events are often tracked from model callbacks. Save inside a
+    # savepoint so the failed insert can be rolled back on its own.
+    #
+    # The exception has to escape the block for Active Record to issue
+    # ROLLBACK TO SAVEPOINT, so callers rescue outside of it.
+    def save_record!(record)
+      if mongoid?(record.class)
+        record.save!
+      else
+        record.class.transaction(requires_new: true) do
+          record.save!
+        end
+      end
+    end
+
+    def mongoid?(model)
+      defined?(Mongoid::Document) && model < Mongoid::Document
+    end
 
     def visit_model
       ::Ahoy::Visit

--- a/test/tracker_test.rb
+++ b/test/tracker_test.rb
@@ -37,6 +37,26 @@ class TrackerTest < Minitest::Test
     assert_nil event.user_id
   end
 
+  # Postgres aborts the entire transaction when a statement fails, so rescuing
+  # the unique violation in Ruby is not enough to leave the transaction usable.
+  # The `visitable` macro creates visits from a before_create hook, i.e. inside
+  # the record's own transaction.
+  def test_duplicate_visit_token_does_not_abort_transaction
+    skip if ENV["ADAPTER"] == "mongoid"
+
+    visit_token = SecureRandom.uuid
+    Ahoy::Visit.create!(visit_token: visit_token, started_at: Time.current)
+
+    ActiveRecord::Base.transaction do
+      # A concurrent request already created this visit.
+      Ahoy::Tracker.new(visit_token: visit_token).track_visit
+      User.create!(name: "Test")
+    end
+
+    assert_equal 1, Ahoy::Visit.count
+    assert_equal 1, User.count
+  end
+
   def test_user_option
     user = Struct.new(:id).new(123)
     ahoy = Ahoy::Tracker.new(user: user)


### PR DESCRIPTION
## Problem

`DatabaseStore#track_visit` relies on the unique index on `visit_token` as concurrency control, and rescues the resulting violation:

```ruby
def track_visit(data)
  @visit = visit_model.create!(slice_data(visit_model, data))
rescue => e
  raise e unless unique_exception?(e)
  ...
end
```

On Postgres, that rescue is not sufficient. Postgres aborts the **entire transaction** when any statement fails, so catching the Ruby exception leaves the connection in an aborted state. Every subsequent statement fails with `current transaction is aborted`.

This matters because the `visitable` macro creates visits from a `before_create` hook — that is, inside the record's own transaction:

```ruby
def set_ahoy_visit
  self.visit ||= Ahoy.instance.try(:visit_or_create)
end
```

So when two concurrent requests share a visit token and one loses the race, the *host application's* record fails to save:

```
ActiveRecord::StatementInvalid: PG::InFailedSqlTransaction: ERROR:
current transaction is aborted, commands ignored until end of transaction block
```

Rails does not open a savepoint for a nested `save`, so there is nothing to roll back to. In our app this silently cost us lead records — the visit insert lost a race, and the lead insert behind it died with the transaction.

`track_event` rescues `event.save!` the same way and has the same hazard for anyone who adds a unique index to `ahoy_events`.

## Why this went unnoticed

It's Postgres-only. MySQL and SQLite fail just the offending statement and leave the transaction usable. I added the regression test before the fix and confirmed it fails on `ADAPTER=postgresql` and passes on `ADAPTER=sqlite3` unchanged.

## Fix

Save inside a savepoint (`transaction(requires_new: true)`) so the failed insert can be rolled back on its own.

The subtlety worth calling out: the exception has to **escape** the block for Active Record to issue `ROLLBACK TO SAVEPOINT`. Wrapping the existing rescue would not work — the block would exit normally and Active Record would issue `RELEASE SAVEPOINT`, which itself fails on an aborted transaction. Hence `save_record!` raises and the callers rescue outside of it.

Mongoid is branched around the savepoint and behaves exactly as before. I extracted the existing inline `visit_model < Mongoid::Document` check in `geocode` into a `mongoid?` helper rather than duplicate it.

## Cost

None on the common path. Active Record collapses the savepoint into the parent when there is nothing to preserve:

```
# top level, no enclosing transaction -- identical SQL to before
BEGIN
INSERT INTO "ahoy_visits" ...
COMMIT
```

A real savepoint is only emitted when the enclosing transaction has writes to protect, and I verified those writes survive the rollback:

```
BEGIN
INSERT INTO "users" ...                  <-- survives
SAVEPOINT active_record_1
INSERT INTO "ahoy_visits" ...            <-- duplicate, fails
ROLLBACK TO SAVEPOINT active_record_1
INSERT INTO "users" ...
COMMIT
```

## Testing

`test_duplicate_visit_token_does_not_abort_transaction` in `test/tracker_test.rb`, skipped on Mongoid.

Full suite green locally on `sqlite3` (91 runs) and `postgresql` (133 runs). I could not build `mysql2` locally, so MySQL, Trilogy and Mongoid are covered only by CI here — opening as a draft so the matrix can run.